### PR TITLE
[Fix] Fix horizontal page jump

### DIFF
--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -23,8 +23,8 @@ import LiquidityMiningCampaign from './Pools/LiquidityMiningCampaign'
 import NetworkWarningModal from '../components/NetworkWarningModal'
 import { Slide, ToastContainer } from 'react-toastify'
 import 'react-toastify/dist/ReactToastify.css'
-import AOS from 'aos';
-import 'aos/dist/aos.css';
+import AOS from 'aos'
+import 'aos/dist/aos.css'
 import Bridge from './Bridge'
 
 import Rewards from './Rewards'
@@ -76,10 +76,14 @@ export default function App() {
   const theme = useContext(ThemeContext)
 
   useEffect(() => {
-    setTimeout(function () { AOS.init({
+    document.body.classList.add('no-margin')
+
+    setTimeout(function() {
+      AOS.init({
         duration: 500
-    }); }, 1000);
-  }, []);
+      })
+    }, 1000)
+  }, [])
 
   return (
     <Suspense fallback={null}>

--- a/src/theme/index.tsx
+++ b/src/theme/index.tsx
@@ -228,6 +228,10 @@ html {
 a {
   text-decoration: none;
 }
+
+body.no-margin {
+  margin: 0 !important;
+}
 `
 
 export const ThemedGlobalStyle = createGlobalStyle`


### PR DESCRIPTION
# Summary

Fixes #738 

Fix body margin added by react-remove-scroll-bar lib.

https://user-images.githubusercontent.com/23079677/158165532-d8521cee-fb0c-4c61-be3b-aaf9a9a1cb18.mp4


# To Test

1. Open any modal
- [ ] Verify if there isn't a horizontal page jump

# Background

Found this as the only solution for the css that react-remove-scroll-bar is injecting with `!impotatnt` property. The only other solution I found is to use a better modal lib that has a good scrolling prevention solution.

