### PR TITLE
fix: add transparent border

### DIFF
--- a/src/components/Badge/Carrot/index.tsx
+++ b/src/components/Badge/Carrot/index.tsx
@@ -6,7 +6,7 @@ import { MouseoverTooltip } from '../../Tooltip'
 
 const KpiBadge = styled.div<{ isGreyed: boolean }>`
   height: 16px;
-  border: ${props => !props.isGreyed && `solid 1.5px ${props.theme.orange1}`};
+  border: ${props => (props.isGreyed ? `solid 1.5px transparent` : `solid 1.5px ${props.theme.orange1}`)};
   color: ${props => (props.isGreyed ? props.theme.purple2 : props.theme.orange1)};
   svg {
     > path {
@@ -32,7 +32,7 @@ const StyledCarrotLogo = styled(CarrotLogo)`
   }
 `
 
-const CarrotBadge = ({ isGreyed = false }) => {
+const CarrotBadge = ({ isGreyed = false }: { isGreyed?: boolean }) => {
   return (
     <MouseoverTooltip content="Rewards at least a Carrot KPI token">
       <KpiBadge isGreyed={isGreyed}>

--- a/src/components/Badge/Carrot/index.tsx
+++ b/src/components/Badge/Carrot/index.tsx
@@ -6,7 +6,8 @@ import { MouseoverTooltip } from '../../Tooltip'
 
 const KpiBadge = styled.div<{ isGreyed: boolean }>`
   height: 16px;
-  border: ${props => (props.isGreyed ? `solid 1.5px transparent` : `solid 1.5px ${props.theme.orange1}`)};
+  border: solid 1px;
+  border-color: ${props => (props.isGreyed ? `transparent` : `${props.theme.orange1}`)};
   color: ${props => (props.isGreyed ? props.theme.purple2 : props.theme.orange1)};
   svg {
     > path {
@@ -23,10 +24,11 @@ const KpiBadge = styled.div<{ isGreyed: boolean }>`
   letter-spacing: 0.04em;
   display: flex;
   align-items: center;
-  padding: 0 4px;
+  padding: 0 2px;
 `
 const StyledCarrotLogo = styled(CarrotLogo)`
-  margin-right: 4px;
+  width: 16px;
+  height: 6px;
   > path {
     fill: #f2994a;
   }

--- a/src/components/Pool/PairsList/Pair/index.tsx
+++ b/src/components/Pool/PairsList/Pair/index.tsx
@@ -34,11 +34,10 @@ const SizedCard = styled(DarkCard)`
 
 const FarmingBadge = styled.div<{ isGreyed?: boolean }>`
   height: 16px;
-  border: ${props => !props.isGreyed && `solid 1.5px ${props.theme.green2}`};
+  border: ${props => (props.isGreyed ? `solid 1.5px transparent` : `solid 1.5px ${props.theme.green2}`)};
   div {
     color: ${props => (props.isGreyed ? props.theme.purple2 : props.theme.green2)};
   }
-
   border-radius: 6px;
   width: fit-content;
   display: flex;
@@ -54,7 +53,6 @@ const FarmingBadge = styled.div<{ isGreyed?: boolean }>`
     }
   }
   font-weight: 700;
-  margin-left: 3px;
   font-size: 9px;
   line-height: 9px;
   letter-spacing: 0.02em;

--- a/src/components/Pool/PairsList/Pair/index.tsx
+++ b/src/components/Pool/PairsList/Pair/index.tsx
@@ -34,7 +34,8 @@ const SizedCard = styled(DarkCard)`
 
 const FarmingBadge = styled.div<{ isGreyed?: boolean }>`
   height: 16px;
-  border: ${props => (props.isGreyed ? `solid 1.5px transparent` : `solid 1.5px ${props.theme.green2}`)};
+  border: solid 1px;
+  border-color: ${props => (props.isGreyed ? `transparent` : `${props.theme.green2}`)};
   div {
     color: ${props => (props.isGreyed ? props.theme.purple2 : props.theme.green2)};
   }
@@ -44,9 +45,10 @@ const FarmingBadge = styled.div<{ isGreyed?: boolean }>`
   justify-content: center;
   align-items: center;
   border-radius: 4px;
-  padding: 0 4px;
+  padding: 0 2px;
   background-color: ${props => props.isGreyed && props.theme.bg3};
   opacity: ${props => props.isGreyed && '0.5'};
+  gap: 4px;
   svg {
     > path {
       fill: ${props => (props.isGreyed ? props.theme.purple2 : props.theme.green2)};
@@ -60,7 +62,6 @@ const FarmingBadge = styled.div<{ isGreyed?: boolean }>`
 
 const BadgeText = styled.div`
   font-weight: 700;
-  margin-left: 3px;
   font-size: 9px;
   line-height: 9px;
   letter-spacing: 0.02em;


### PR DESCRIPTION
# Summary

Fixes #745 
Add a transparent border for state badges on `greyed` state.
Also remove the left margin for the farming badge, since it's missing in figma.

![image](https://user-images.githubusercontent.com/9011637/158244648-fa666413-f49f-4ccc-85b8-7d771e4fef2a.png)

  # To Test

1. Open the page `Liquidity`
- [ ]  Verify that active and inactive badges are the same size

