### PR TITLE
fix: add background gradient for pair cards

### DIFF
--- a/src/components/Pool/LoadingList/LoadingCard/index.tsx
+++ b/src/components/Pool/LoadingList/LoadingCard/index.tsx
@@ -17,6 +17,11 @@ const SizedCard = styled(DarkCard)<{ isMobile: boolean }>`
    height:128px;
        overflow: hidden;
   `};
+  ::before {
+    background-blend-mode: normal, overlay, normal;
+    background: linear-gradient(143.3deg, rgba(46, 23, 242, 0.5) -185.11%, rgba(46, 23, 242, 0) 49.63%),
+      linear-gradient(113.18deg, rgba(255, 255, 255, 0.15) -0.1%, rgba(0, 0, 0, 0) 98.9%), #171621;
+  }
 `
 const MobileHidden = styled(Box)<{ isMobile: boolean }>`
   display: flex;

--- a/src/components/Pool/PairsList/Pair/index.tsx
+++ b/src/components/Pool/PairsList/Pair/index.tsx
@@ -30,6 +30,11 @@ const SizedCard = styled(DarkCard)`
     height: initial;
     padding: 22px 16px;
   `}
+  ::before {
+    background-blend-mode: normal, overlay, normal;
+    background: linear-gradient(143.3deg, rgba(46, 23, 242, 0.5) -185.11%, rgba(46, 23, 242, 0) 49.63%),
+      linear-gradient(113.18deg, rgba(255, 255, 255, 0.15) -0.1%, rgba(0, 0, 0, 0) 98.9%), #171621;
+  }
 `
 
 const FarmingBadge = styled.div<{ isGreyed?: boolean }>`


### PR DESCRIPTION
# Summary

Fixes #746 

Add background gradient for `SizedCard` styled component, inside `Pair` and `LoadingCard` components.
The specifies only the gradient for the badge in the final state, but I also added the gradient for the loading state, is that ok?

final state:
![before](https://user-images.githubusercontent.com/9011637/158251999-80bd59bf-28aa-4a76-9f93-858803c41126.png)
![after](https://user-images.githubusercontent.com/9011637/158252025-907b1f7d-be80-4c25-b02d-0ec899b68664.png)

loading state:
![before-loading](https://user-images.githubusercontent.com/9011637/158252071-f38214f7-9696-4a72-962e-e5aad9074924.png)
![after-loading](https://user-images.githubusercontent.com/9011637/158252084-137dca61-f98d-48cf-97b6-8965f20bd5da.png)


  # To Test

1. Open the page `Liquidity`
- [ ] Verify that the pair badges have the background gradient

 # Background

Since the `DarkCard` component is used elsewhere in the application I decided to extend the style only in the required places.

