### PR TITLE
fix: add loading balances spacing

### DIFF
--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -287,10 +287,6 @@ const StyledChevron = styled(ChevronUp)<{ isOpen: boolean }>`
   transform: ${({ isOpen }) => (isOpen ? 'rotate(0deg)' : 'rotate(180deg)')};
 `
 
-export const SpacedSkeleton = styled(Skeleton)`
-  margin-right: 3px;
-`
-
 function Header() {
   const { account, chainId } = useActiveWeb3React()
   const { t } = useTranslation()
@@ -382,7 +378,7 @@ function Header() {
                 {!account ? (
                   '0.000'
                 ) : !userNativeCurrencyBalance ? (
-                  <SpacedSkeleton width="37px" />
+                  <Skeleton width="37px" style={{ marginRight: '3px' }} />
                 ) : (
                   userNativeCurrencyBalance.toFixed(3)
                 )}{' '}

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -287,6 +287,10 @@ const StyledChevron = styled(ChevronUp)<{ isOpen: boolean }>`
   transform: ${({ isOpen }) => (isOpen ? 'rotate(0deg)' : 'rotate(180deg)')};
 `
 
+export const SpacedSkeleton = styled(Skeleton)`
+  margin-right: 3px;
+`
+
 function Header() {
   const { account, chainId } = useActiveWeb3React()
   const { t } = useTranslation()
@@ -378,7 +382,7 @@ function Header() {
                 {!account ? (
                   '0.000'
                 ) : !userNativeCurrencyBalance ? (
-                  <Skeleton width="40px" />
+                  <SpacedSkeleton width="37px" />
                 ) : (
                   userNativeCurrencyBalance.toFixed(3)
                 )}{' '}

--- a/src/components/Header/swpr-info/index.tsx
+++ b/src/components/Header/swpr-info/index.tsx
@@ -2,8 +2,7 @@ import { TokenAmount } from '@swapr/sdk'
 import React from 'react'
 import styled from 'styled-components'
 import { useActiveWeb3React } from '../../../hooks'
-import { Amount } from '../index'
-import Skeleton from 'react-loading-skeleton'
+import { Amount, SpacedSkeleton } from '../index'
 
 const StakeIndicator = styled.div`
   display: flex;
@@ -35,7 +34,7 @@ export function SwprInfo({ onToggleClaimPopup, newSwprBalance, hasActiveCampaign
   return (
     <Wrapper onClick={onToggleClaimPopup} hide={!account}>
       <Amount borderRadius={hasActiveCampaigns ? '8px 0px 0px 8px !important;' : ''} zero={false} clickable>
-        {!account ? '0.000' : !newSwprBalance ? <Skeleton width="40px" /> : newSwprBalance.toFixed(3)} SWPR
+        {!account ? '0.000' : !newSwprBalance ? <SpacedSkeleton width="37px" /> : newSwprBalance.toFixed(3)} SWPR
       </Amount>
       {hasActiveCampaigns && <StakeIndicator>STAKE</StakeIndicator>}
     </Wrapper>

--- a/src/components/Header/swpr-info/index.tsx
+++ b/src/components/Header/swpr-info/index.tsx
@@ -1,8 +1,9 @@
 import { TokenAmount } from '@swapr/sdk'
 import React from 'react'
+import Skeleton from 'react-loading-skeleton'
 import styled from 'styled-components'
 import { useActiveWeb3React } from '../../../hooks'
-import { Amount, SpacedSkeleton } from '../index'
+import { Amount } from '../index'
 
 const StakeIndicator = styled.div`
   display: flex;
@@ -34,7 +35,14 @@ export function SwprInfo({ onToggleClaimPopup, newSwprBalance, hasActiveCampaign
   return (
     <Wrapper onClick={onToggleClaimPopup} hide={!account}>
       <Amount borderRadius={hasActiveCampaigns ? '8px 0px 0px 8px !important;' : ''} zero={false} clickable>
-        {!account ? '0.000' : !newSwprBalance ? <SpacedSkeleton width="37px" /> : newSwprBalance.toFixed(3)} SWPR
+        {!account ? (
+          '0.000'
+        ) : !newSwprBalance ? (
+          <Skeleton width="37px" style={{ marginRight: '3px' }} />
+        ) : (
+          newSwprBalance.toFixed(3)
+        )}{' '}
+        SWPR
       </Amount>
       {hasActiveCampaigns && <StakeIndicator>STAKE</StakeIndicator>}
     </Wrapper>


### PR DESCRIPTION
# Summary

Fixes #744 

Add right spacing for skeleton components inside the `Header` component.

before:
![before](https://user-images.githubusercontent.com/9011637/158256741-adfa0fc1-573b-4da6-a248-5a1f5b2416a6.png)

after:
![after](https://user-images.githubusercontent.com/9011637/158256775-a258b001-1017-46f3-8c1a-eb18107a780a.png)

  # To Test

1. Reload the page
- [ ] Verify the balance loaders in the header have a right margin
