### PR TITLE
fix: the icons background inside stake card

### DIFF
--- a/src/components/Pool/LiquidityMiningCampaignView/StakeCard/index.tsx
+++ b/src/components/Pool/LiquidityMiningCampaignView/StakeCard/index.tsx
@@ -341,7 +341,7 @@ export default function StakeCard({
 
   return (
     <>
-      <StyledPositionCard>
+      <StyledPositionCard style={{ zIndex: 1 }}>
         <AutoColumn gap="8px">
           <Flex flexDirection="column">
             <Box mb="20px">


### PR DESCRIPTION
# Summary

Fixes #688

Allow the icon's background-color property to take effect by adjusting the z-index of the parent component.

before:
![image](https://user-images.githubusercontent.com/9011637/158692105-01582b20-44a4-4d98-b762-700ba9a7a636.png)
after:
![after](https://user-images.githubusercontent.com/9011637/158691816-b99816e7-70a8-463a-ab50-736e8f0dd227.png)

  # To Test

1. Open the page `Rewards`
- [ ] Verify that the icons have the white background

