### PR TITLE
Fix slippage tolerance & deadline validation

### DIFF
--- a/src/components/TransactionSettings/index.tsx
+++ b/src/components/TransactionSettings/index.tsx
@@ -115,7 +115,9 @@ export default function SlippageTabs({
   const [deadlineFocused, setDeadlineFocused] = useState(false)
 
   const slippageInputIsValid =
-    slippageInput === '' || (rawSlippage / 100).toFixed(2) === Number.parseFloat(slippageInput).toFixed(2)
+    slippageInput === '' ||
+    (!Number.isNaN(Number(slippageInput)) &&
+      (rawSlippage / 100).toFixed(2) === Number.parseFloat(slippageInput).toFixed(2))
   const preferredGasPriceInputIsValid =
     preferredGasPriceInput === '' ||
     (!Number.isNaN(Number(preferredGasPriceInput)) &&
@@ -161,7 +163,12 @@ export default function SlippageTabs({
 
     try {
       const valueAsIntFromRoundedFloat = Number.parseInt((Number.parseFloat(value) * 100).toString())
-      if (!Number.isNaN(valueAsIntFromRoundedFloat) && valueAsIntFromRoundedFloat < 5000) {
+
+      if (
+        !Number.isNaN(valueAsIntFromRoundedFloat) &&
+        valueAsIntFromRoundedFloat >= 0 &&
+        valueAsIntFromRoundedFloat < 5000
+      ) {
         setRawSlippage(valueAsIntFromRoundedFloat)
       }
     } catch {}
@@ -187,6 +194,7 @@ export default function SlippageTabs({
     try {
       const valueAsInt: number = Number.parseInt(value) * 60
       if (!Number.isNaN(valueAsInt) && valueAsInt > 0) {
+        if (Number(valueAsInt) > Number.MAX_SAFE_INTEGER) throw new Error('Preferred gas price overflow')
         setDeadline(valueAsInt)
       }
     } catch {}

--- a/src/components/TransactionSettings/index.tsx
+++ b/src/components/TransactionSettings/index.tsx
@@ -158,44 +158,44 @@ export default function SlippageTabs({
     deadlineError = undefined
   }
 
-  function parseCustomSlippage(value: string) {
-    setSlippageInput(value)
+  function parseCustomSlippage(slippage: string) {
+    setSlippageInput(slippage)
 
     try {
-      const valueAsIntFromRoundedFloat = Number.parseInt((Number.parseFloat(value) * 100).toString())
+      const slippageAsIntFromRoundedFloat = Number.parseInt((Number.parseFloat(slippage) * 100).toString())
 
       if (
-        !Number.isNaN(valueAsIntFromRoundedFloat) &&
-        valueAsIntFromRoundedFloat >= 0 &&
-        valueAsIntFromRoundedFloat < 5000
+        !Number.isNaN(slippageAsIntFromRoundedFloat) &&
+        slippageAsIntFromRoundedFloat >= 0 &&
+        slippageAsIntFromRoundedFloat < 5000
       ) {
-        setRawSlippage(valueAsIntFromRoundedFloat)
+        setRawSlippage(slippageAsIntFromRoundedFloat)
       }
     } catch {}
   }
 
-  function parseCustomPreferredGasPrice(value: string) {
-    setPreferredGasPriceInput(value)
+  function parseCustomPreferredGasPrice(gasPrice: string) {
+    setPreferredGasPriceInput(gasPrice)
 
     try {
-      const valueAsFloat = Number.parseFloat(value)
-      if (!Number.isNaN(valueAsFloat) && valueAsFloat > 0) {
+      const gasPriceAsFloat = Number.parseFloat(gasPrice)
+      if (!Number.isNaN(gasPriceAsFloat) && gasPriceAsFloat > 0) {
         // converting to wei
-        const rawPreferredGasPriceWei = new Decimal(valueAsFloat.toFixed(10)).times('1000000000').toString()
+        const rawPreferredGasPriceWei = new Decimal(gasPriceAsFloat.toFixed(10)).times('1000000000').toString()
         if (Number(rawPreferredGasPriceWei) > Number.MAX_SAFE_INTEGER) throw new Error('Preferred gas price overflow')
         setRawPreferredGasPrice(rawPreferredGasPriceWei)
       }
     } catch {}
   }
 
-  function parseCustomDeadline(value: string) {
-    setDeadlineInput(value)
+  function parseCustomDeadline(customDeadline: string) {
+    setDeadlineInput(customDeadline)
 
     try {
-      const valueAsInt: number = Number.parseInt(value) * 60
-      if (!Number.isNaN(valueAsInt) && valueAsInt > 0) {
-        if (Number(valueAsInt) > Number.MAX_SAFE_INTEGER) throw new Error('Preferred gas price overflow')
-        setDeadline(valueAsInt)
+      const customDeadlineAsInt: number = Number.parseInt(customDeadline) * 60
+      if (!Number.isNaN(customDeadlineAsInt) && customDeadlineAsInt > 0) {
+        if (Number(customDeadlineAsInt) > Number.MAX_SAFE_INTEGER) throw new Error('Deadline overflow')
+        setDeadline(customDeadlineAsInt)
       }
     } catch {}
   }

--- a/src/components/TransactionSettings/index.tsx
+++ b/src/components/TransactionSettings/index.tsx
@@ -117,12 +117,14 @@ export default function SlippageTabs({
   const slippageInputIsValid =
     slippageInput === '' ||
     (!Number.isNaN(Number(slippageInput)) &&
-      (rawSlippage / 100).toFixed(2) === Number.parseFloat(slippageInput).toFixed(2))
+      rawSlippage.toFixed(2) === Math.round(Number.parseFloat(slippageInput) * 100).toFixed(2))
+
   const preferredGasPriceInputIsValid =
     preferredGasPriceInput === '' ||
     (!Number.isNaN(Number(preferredGasPriceInput)) &&
       rawPreferredGasPrice ===
         new Decimal(Number.parseFloat(preferredGasPriceInput).toFixed(10)).times('1000000000').toString())
+
   const deadlineInputIsValid = deadlineInput === '' || (deadline / 60).toString() === deadlineInput
 
   let slippageError: SlippageError | undefined
@@ -162,11 +164,11 @@ export default function SlippageTabs({
     setSlippageInput(slippage)
 
     try {
-      const slippageAsIntFromRoundedFloat = Number.parseInt((Number.parseFloat(slippage) * 100).toString())
+      const slippageAsIntFromRoundedFloat = Number.parseInt(Math.round(Number.parseFloat(slippage) * 100).toString())
 
       if (
         !Number.isNaN(slippageAsIntFromRoundedFloat) &&
-        slippageAsIntFromRoundedFloat >= 0 &&
+        slippageAsIntFromRoundedFloat > 0 &&
         slippageAsIntFromRoundedFloat < 5000
       ) {
         setRawSlippage(slippageAsIntFromRoundedFloat)


### PR DESCRIPTION
# Summary

Fixes #776 

Added slippage tolerance validation for negative values.
![image](https://user-images.githubusercontent.com/88723742/158808178-42417fdb-f913-4186-bc63-ef5e1fd85a95.png)

Prevent deadline overflow bug.
![image](https://user-images.githubusercontent.com/88723742/158808851-843f5f89-0344-4dbf-9498-3dd144764c65.png)


  # To Test

1. Open the setting popup
- [ ] Negative value for slippage tolerance is not acceptable
- [ ] In Transaction deadline input press and hold button - page shouldn't crash anymore
- [ ] Page doesn't crash after settings changes
