### PR TITLE
Feature/omnibridge use token

### DIFF
--- a/src/components/SearchModalBridge/CurrencySearch.tsx
+++ b/src/components/SearchModalBridge/CurrencySearch.tsx
@@ -2,7 +2,7 @@ import { Currency, Token } from '@swapr/sdk'
 import React, { KeyboardEvent, RefObject, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { FixedSizeList } from 'react-window'
-import { useToken, useSearchInactiveTokenLists } from '../../hooks/Tokens'
+import { useSearchInactiveTokenLists } from '../../hooks/Tokens'
 import { CloseIcon, TYPE } from '../../theme'
 import { isAddress } from '../../utils'
 import Column, { AutoColumn } from '../Column'
@@ -19,7 +19,7 @@ import useDebounce from '../../hooks/useDebounce'
 import { useActiveWeb3React } from '../../hooks'
 import { useNativeCurrency } from '../../hooks/useNativeCurrency'
 import { ButtonDark2 } from '../Button'
-import { useAllBridgeTokens } from '../../services/Omnibridge/hooks/Omnibrige.hooks'
+import { useBridgeSupportedTokens, useBridgeToken } from '../../services/Omnibridge/hooks/Omnibrige.hooks'
 
 const ContentWrapper = styled(Column)`
   width: 100%;
@@ -82,12 +82,12 @@ export function CurrencySearch({
 
   const [invertSearchOrder] = useState<boolean>(false)
 
-  const allTokens = useAllBridgeTokens()
+  const allTokens = useBridgeSupportedTokens()
 
   // if they input an address, use it
   const isAddressSearch = isAddress(debouncedQuery)
 
-  const searchToken = useToken(debouncedQuery)
+  const searchToken = useBridgeToken(debouncedQuery)
 
   const tokenComparator = useTokenComparator(invertSearchOrder)
 

--- a/src/components/SearchModalBridge/ManageLists.tsx
+++ b/src/components/SearchModalBridge/ManageLists.tsx
@@ -4,7 +4,7 @@ import { Separator } from './styleds'
 import ListToggle from '../Toggle/ListToggle'
 import { UNSUPPORTED_LIST_URLS } from '../../constants/lists'
 import { useActiveWeb3React } from '../../hooks'
-import { useActiveListsHandlers, useAllBridgeLists } from '../../services/Omnibridge/hooks/Omnibrige.hooks'
+import { useActiveListsHandlers, useBridgeSupportedLists } from '../../services/Omnibridge/hooks/Omnibrige.hooks'
 import styled, { ThemeContext } from 'styled-components/macro'
 import Column, { AutoColumn } from '../Column'
 import { TYPE } from '../../theme'
@@ -43,7 +43,7 @@ function listUrlRowHTMLId(listUrl: string) {
 
 function ListRow({ listUrl }: { listUrl: string }) {
   const { chainId } = useActiveWeb3React()
-  const listsByUrl = useAllBridgeLists()
+  const listsByUrl = useBridgeSupportedLists()
   const { activateList, deactivateList, isListActive } = useActiveListsHandlers()
   const list = listsByUrl[listUrl]
   const tokensAmountInCurrentChain = useMemo(() => {
@@ -91,7 +91,7 @@ const ListContainer = styled.div`
 `
 
 export function ManageLists() {
-  const lists = useAllBridgeLists()
+  const lists = useBridgeSupportedLists()
 
   const renderableLists = useMemo(() => {
     return Object.keys(lists).filter(listUrl => {

--- a/src/hooks/Tokens.ts
+++ b/src/hooks/Tokens.ts
@@ -106,7 +106,11 @@ export function useIsUserAddedPair(pair: Pair): boolean {
 // parse a name or symbol from a token response
 const BYTES32_REGEX = /^0x[a-fA-F0-9]{64}$/
 
-function parseStringOrBytes32(str: string | undefined, bytes32: string | undefined, defaultValue: string): string {
+export function parseStringOrBytes32(
+  str: string | undefined,
+  bytes32: string | undefined,
+  defaultValue: string
+): string {
   return str && str.length > 0
     ? str
     : // need to check for proper bytes string and valid terminator

--- a/src/hooks/useContract.ts
+++ b/src/hooks/useContract.ts
@@ -52,10 +52,12 @@ export function useTokenContract(tokenAddress?: string, withSignerIfPossible?: b
   return useContract(tokenAddress, ERC20_ABI, withSignerIfPossible)
 }
 
-export function useWrappingToken(currency?: Currency): Token | undefined {
-  const { chainId } = useActiveWeb3React()
-  if (!chainId || !currency || !Currency.isNative(currency)) return undefined
-  return Token.getNativeWrapper(chainId)
+export function useWrappingToken(currency?: Currency, chainId?: ChainId): Token | undefined {
+  const { chainId: activeChainId } = useActiveWeb3React()
+
+  const selectedChainId = chainId ?? activeChainId
+  if (!selectedChainId || !currency || !Currency.isNative(currency)) return undefined
+  return Token.getNativeWrapper(selectedChainId)
 }
 
 function useWrappingTokenAbi(token?: Token): any | undefined {

--- a/src/hooks/useNativeCurrency.ts
+++ b/src/hooks/useNativeCurrency.ts
@@ -1,9 +1,10 @@
-import { Currency } from '@swapr/sdk'
+import { ChainId, Currency } from '@swapr/sdk'
 import { useActiveWeb3React } from '.'
 
-export function useNativeCurrency(): Currency {
-  const { chainId } = useActiveWeb3React()
+export function useNativeCurrency(chainId?: ChainId): Currency {
+  const { chainId: activeChainId } = useActiveWeb3React()
+  const selectedChainId = chainId ?? activeChainId
   // fallback to ether if chain id is not defined
-  if (!chainId) return Currency.ETHER
-  return Currency.getNative(chainId) || Currency.ETHER
+  if (!selectedChainId) return Currency.ETHER
+  return Currency.getNative(selectedChainId) || Currency.ETHER
 }

--- a/src/pages/Bridge/index.tsx
+++ b/src/pages/Bridge/index.tsx
@@ -19,7 +19,7 @@ import { BridgeTabs, isNetworkDisabled } from './utils'
 import { createNetworksList, getNetworkOptions } from '../../utils/networksList'
 import { useOmnibridge } from '../../services/Omnibridge/OmnibridgeProvider'
 import { AppState } from '../../state'
-import { selectAllTransactions } from '../../services/Omnibridge/store/Omnibridge.selectors'
+import { selectBridgeTransactions } from '../../services/Omnibridge/store/Omnibridge.selectors'
 import { omnibridgeUIActions } from '../../services/Omnibridge/store/UI.reducer'
 import { BridgeSelectionWindow } from './BridgeSelectionWindow'
 import CurrencyInputPanel from '../../components/CurrencyInputPanelBridge'
@@ -82,7 +82,7 @@ export default function Bridge() {
   const { chainId, account } = useActiveWeb3React()
   const omnibridge = useOmnibridge()
 
-  const bridgeSummaries = useSelector((state: AppState) => selectAllTransactions(state, account ? account : ''))
+  const bridgeSummaries = useSelector((state: AppState) => selectBridgeTransactions(state, account ? account : ''))
 
   useBridgeFetchDynamicLists()
   //new modal interface


### PR DESCRIPTION
# Summary

Closes #754
- changed names for some selectors/function/hooks so they are more descriptive about what they do
- added `useBridgeToken` which is bridge equivalent `useToken`
- added `useBridgeCurrency` which is bridge equivalent to `useCurrency`
- refactored `useNativeCurrency` so it accepts `chainId` as optional props and will return native currency fr given chain (not only for active)

Thanks to these changes we are now able to find token regardless of active chain 

