### PR TITLE
Show eth balance only when wallet connected

### DIFF
--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -176,11 +176,11 @@ const HeaderSubRow = styled(RowFlat)`
   `};
 `
 
-export const Amount = styled.p<{ clickable?: boolean; zero: boolean; borderRadius?: string; hide?: boolean }>`
+export const Amount = styled.p<{ clickable?: boolean; zero: boolean; borderRadius?: string }>`
   padding: 6px 8px;
   margin: 0;
   max-height: 22px;
-  display: ${({ hide }) => (hide ? 'none' : 'inline-flex')};
+  display: inline-flex;
   font-weight: bold;
   font-size: 10px;
   line-height: 11px;
@@ -380,18 +380,14 @@ function Header() {
             onToggleClaimPopup={toggleClaimPopup}
           />
           <UnsupportedNetworkPopover show={isUnsupportedNetworkModal}>
-            {isUnsupportedChainIdError ? (
-              <Amount zero>{'UNSUPPORTED NETWORK'}</Amount>
-            ) : (
-              <Amount zero={!!userNativeCurrencyBalance?.equalTo('0')} hide={!account && !isUnsupportedChainIdError}>
-                {!account ? (
-                  '0.000'
-                ) : !userNativeCurrencyBalance ? (
-                  <Skeleton width="37px" style={{ marginRight: '3px' }} />
+            {isUnsupportedChainIdError && <Amount zero>{'UNSUPPORTED NETWORK'}</Amount>}
+            {account && !isUnsupportedChainIdError && (
+              <Amount zero={!!userNativeCurrencyBalance?.equalTo('0')}>
+                {userNativeCurrencyBalance ? (
+                  `${userNativeCurrencyBalance.toFixed(3)} ${nativeCurrency.symbol}`
                 ) : (
-                  userNativeCurrencyBalance.toFixed(3)
-                )}{' '}
-                {nativeCurrency.symbol}
+                  <Skeleton width="37px" style={{ marginRight: '3px' }} />
+                )}
               </Amount>
             )}
           </UnsupportedNetworkPopover>

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -176,11 +176,11 @@ const HeaderSubRow = styled(RowFlat)`
   `};
 `
 
-export const Amount = styled.p<{ clickable?: boolean; zero: boolean; borderRadius?: string }>`
+export const Amount = styled.p<{ clickable?: boolean; zero: boolean; borderRadius?: string; hide?: boolean }>`
   padding: 6px 8px;
   margin: 0;
   max-height: 22px;
-  display: inline-flex;
+  display: ${({ hide }) => (hide ? 'none' : 'inline-flex')};
   font-weight: bold;
   font-size: 10px;
   line-height: 11px;
@@ -203,8 +203,8 @@ export const Amount = styled.p<{ clickable?: boolean; zero: boolean; borderRadiu
     margin-left: 7px;
   }
 `
-const GasInfo = styled.div`
-  display: flex;
+const GasInfo = styled.div<{ hide: boolean }>`
+  display: ${({ hide }) => (hide ? 'none' : 'flex')};
   margin-left: 6px;
   padding: 6px 8px;
   border: 1.06481px solid rgba(242, 153, 74, 0.65);
@@ -383,7 +383,7 @@ function Header() {
             {isUnsupportedChainIdError ? (
               <Amount zero>{'UNSUPPORTED NETWORK'}</Amount>
             ) : (
-              <Amount zero={!!userNativeCurrencyBalance?.equalTo('0')}>
+              <Amount zero={!!userNativeCurrencyBalance?.equalTo('0')} hide={!account && !isUnsupportedChainIdError}>
                 {!account ? (
                   '0.000'
                 ) : !userNativeCurrencyBalance ? (
@@ -396,7 +396,7 @@ function Header() {
             )}
           </UnsupportedNetworkPopover>
           {gas.normal !== 0.0 && (
-            <GasInfo onClick={() => setIsGasInfoOpen(!isGasInfoOpen)}>
+            <GasInfo onClick={() => setIsGasInfoOpen(!isGasInfoOpen)} hide={!account || isUnsupportedChainIdError}>
               <GasInfoSvg />
               <Text marginLeft={'4px'} marginRight={'2px'} fontSize={10} fontWeight={600} lineHeight={'9px'}>
                 {gas.normal}

--- a/src/hooks/useGasInfo.ts
+++ b/src/hooks/useGasInfo.ts
@@ -96,7 +96,6 @@ export function useGasInfo(): { loading: boolean; gas: Gas } {
           // There is no fast nor slow gas prices
           normal = parseFloat((parseInt(data.result, 16) / 1e9).toFixed(2))
         }
-        console.log(typeof normal, fast, slow)
         // Update state
         setGas({ normal, fast, slow })
       })


### PR DESCRIPTION
# Summary

Fixes #812 

Show account balance only when user's wallet is connected. The same as gas on Gnosis Chain.

![image](https://user-images.githubusercontent.com/88723742/160017053-d2a7e154-c73d-47ff-be8e-c0b5178bee11.png)
 

  # To Test

1. Open the swapr app
- [ ] Wallet is disconnected - button shows "connect wallet"
- [ ] Account balance is not visible 

2. Switch network to Gnosis Chain
- [ ] Account balance is not visible 
- [ ] Gas icon is not visible 

3. Connect wallet to any network
- [ ] Account balance is visible 
- [ ] 'SWPR' balance is visible

![image](https://user-images.githubusercontent.com/88723742/160017790-39f49724-b7c2-48a2-b4b0-901984d3f0ee.png)

4. Connect wallet to Gnosis Chain
- [ ] Account balance is visible 
- [ ] 'SWPR' balance is visible
- [ ] gas icon is visible and show options if clicked

![image](https://user-images.githubusercontent.com/88723742/160017928-329ef0d1-9bda-42de-9fca-378ba4b8b5c9.png)


