### PR TITLE
[Fix] Enhance user and mobile experience in new Swapbox

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -112,5 +112,11 @@
   "alternateReceiver": "Alternate Receiver",
   "MEVProtectionComingSoon": "MEV Protection (coming soon)",
   "insufficientCurrencyBalance": "Insufficient {{ currency }} balance",
-  "enterCurrencyAmount": "Enter {{ currency }} amount"
+  "enterCurrencyAmount": "Enter {{ currency }} amount",
+  "exchange": "Exchange",
+  "fee": "Fee",
+  "priceImpact": "Price impact",
+  "pImp": "P. Imp.",
+  "minReceived": "Min. Received",
+  "maxSent": "Max Sent"
 }

--- a/src/components/CurrencyInputPanel/index.tsx
+++ b/src/components/CurrencyInputPanel/index.tsx
@@ -9,10 +9,12 @@ import { RowBetween } from '../Row'
 import { TYPE } from '../../theme'
 import NumericalInput from '../Input/NumericalInput'
 import { ReactComponent as DropDown } from '../../assets/images/dropdown.svg'
+import { breakpoints } from '../../utils/theme'
 
 import { useActiveWeb3React } from '../../hooks'
 import { useTranslation } from 'react-i18next'
 import { FiatValueDetails } from '../FiatValueDetails'
+import { limitDigitDecimalPlace } from '../../utils/prices'
 
 const InputRow = styled.div<{ selected: boolean }>`
   ${({ theme }) => theme.flexRowNoWrap}
@@ -76,6 +78,9 @@ const Container = styled.div<{ focused: boolean }>`
   border-radius: 12px;
   transition: border 0.3s ease;
   padding: 18px 22px;
+  @media screen and (max-width: ${breakpoints.md}) {
+    padding: 18px 16px;
+  }
 `
 
 const Content = styled.div``
@@ -217,7 +222,12 @@ export default function CurrencyInputPanel({
           </InputRow>
           <FiatRow>
             <RowBetween>
-              {fiatValue && <FiatValueDetails fiatValue={fiatValue?.toFixed(2)} priceImpact={priceImpact} />}
+              {fiatValue && (
+                <FiatValueDetails
+                  fiatValue={fiatValue?.toFixed(2, { groupSeparator: ',' })}
+                  priceImpact={priceImpact}
+                />
+              )}
               {account && (
                 <TYPE.body
                   onClick={onMax}
@@ -237,7 +247,7 @@ export default function CurrencyInputPanel({
                       <>
                         {customBalanceText ?? t('balance')}
                         <TYPE.small as="span" fontWeight="600" color="text3" style={{ textDecoration: 'underline' }}>
-                          {(balance || selectedCurrencyBalance)?.toSignificant(6)}
+                          {limitDigitDecimalPlace(balance || selectedCurrencyBalance)}
                         </TYPE.small>
                       </>
                     )}

--- a/src/components/FiatValueDetails/index.tsx
+++ b/src/components/FiatValueDetails/index.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import styled from 'styled-components'
 import { TYPE } from '../../theme'
 import { JSBI, Percent } from '@swapr/sdk'
-import { warningFiatSeverity } from '../../utils/prices'
+import { simpleWarningSeverity } from '../../utils/prices'
 import { PRICE_IMPACT_HIGH } from '../../constants'
 
 interface FiatValueDetailsProps {
@@ -16,7 +16,7 @@ const StyledPriceImpact = styled.span<{ warning?: boolean }>`
 `
 
 export function FiatValueDetails({ fiatValue = '0', priceImpact }: FiatValueDetailsProps) {
-  const fiatPriceImpactSeverity = warningFiatSeverity(priceImpact)
+  const fiatPriceImpactSeverity = simpleWarningSeverity(priceImpact)
 
   return (
     <TYPE.body fontWeight="600" fontSize="11px" lineHeight="13px" letterSpacing="0.08em">

--- a/src/components/RecipientField/index.tsx
+++ b/src/components/RecipientField/index.tsx
@@ -1,26 +1,10 @@
-import React, { useState, useEffect, useCallback, useMemo } from 'react'
-import { Flex } from 'rebass/styled-components'
+import React, { useEffect, useCallback, useMemo } from 'react'
 import styled from 'styled-components'
 import { SearchInput } from '../SearchModal/styleds'
-import { RowBetween } from '../Row'
-import { CloseIcon, TYPE } from '../../theme'
+import { TYPE } from '../../theme'
 import useENS from '../../hooks/useENS'
 import { useDispatch } from 'react-redux'
 import { useTranslation } from 'react-i18next'
-
-const AddRecipientButtonStyled = styled.button`
-  font-size: 11px;
-  line-height: 13px;
-  letter-spacing: 0.08em;
-  cursor: pointer;
-  color: ${({ theme }) => theme.text4};
-  outline: none;
-  background: transparent;
-  border: none;
-`
-const CloseIconStyled = styled(CloseIcon)`
-  padding: 0;
-`
 
 const SearchInputStyled = styled(SearchInput)<{ error: boolean }>`
   margin-top: 5px;
@@ -39,7 +23,6 @@ interface RecipientField {
 
 export const RecipientField = ({ recipient, action }: RecipientField) => {
   const { t } = useTranslation()
-  const [showInput, setShowInput] = useState(false)
   const dispatch = useDispatch()
   const { address, loading } = useENS(recipient)
   const error = useMemo(() => Boolean(recipient && recipient.length > 0 && !loading && !address), [
@@ -63,23 +46,11 @@ export const RecipientField = ({ recipient, action }: RecipientField) => {
     }
   }, [action, dispatch])
 
-  const handleClose = useCallback(() => {
-    setShowInput(false)
-    dispatch(action({ recipient: null }))
-  }, [action, dispatch])
-
-  return !showInput ? (
-    <Flex justifyContent="center">
-      <AddRecipientButtonStyled onClick={() => setShowInput(true)}>{t('addRecipient')}</AddRecipientButtonStyled>
-    </Flex>
-  ) : (
+  return (
     <div>
-      <RowBetween>
-        <TYPE.subHeader lineHeight={'11px'} color={'purple3'}>
-          {t('recipient')}
-        </TYPE.subHeader>
-        <CloseIconStyled p={0} onClick={handleClose} />
-      </RowBetween>
+      <TYPE.subHeader lineHeight={'11px'} color={'purple3'}>
+        {t('recipient')}
+      </TYPE.subHeader>
       <SearchInputStyled
         type="text"
         placeholder={t('addressOrENS')}

--- a/src/components/swap/AdvancedSwapDetailsDropdown.tsx
+++ b/src/components/swap/AdvancedSwapDetailsDropdown.tsx
@@ -1,8 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
 import { ChainId, RoutablePlatform, Trade } from '@swapr/sdk'
-import { useLastTruthy } from '../../hooks/useLast'
-import { AdvancedSwapDetails } from './AdvancedSwapDetails'
 import { SwapPlatformSelector } from './SwapPlatformSelector'
 import { AutoColumn } from '../Column'
 import { Settings } from 'react-feather'
@@ -80,15 +78,13 @@ interface AdvancedSwapDetailsDropdownProps {
 export default function AdvancedSwapDetailsDropdown({
   trade,
   allPlatformTrades,
-  onSelectedPlatformChange,
-  ...rest
+  onSelectedPlatformChange
 }: AdvancedSwapDetailsDropdownProps) {
   const { chainId } = useActiveWeb3React()
   const [userPreferredMainnetGasPrice, setUserPreferredMainnetGasPrice] = useUserPreferredGasPrice()
   const [multihopEnabled, toggleMultihop] = useMultihopManager()
   const toggleSettingsMenu = useToggleSettingsMenu()
   const mainnetGasPrices = useMainnetGasPrices()
-  const lastTrade = useLastTruthy(trade)
 
   const getGasPriceClickHandler = (priceVariant: MainnetGasPrice) => () => {
     setUserPreferredMainnetGasPrice(priceVariant)
@@ -108,7 +104,6 @@ export default function AdvancedSwapDetailsDropdown({
           allPlatformTrades={allPlatformTrades}
           onSelectedPlatformChange={onSelectedPlatformChange}
         />
-        <AdvancedSwapDetails {...rest} trade={trade ?? lastTrade ?? undefined} />
       </AdvancedDetailsFooter>
       {chainId === ChainId.MAINNET && !!mainnetGasPrices && (
         <SettingsFlex width="100%">

--- a/src/components/swap/SwapSettings.tsx
+++ b/src/components/swap/SwapSettings.tsx
@@ -37,7 +37,13 @@ const StyledRowFixed = styled(RowFixed)`
   }
 `
 
-export function SwapSettings() {
+export function SwapSettings({
+  showAddRecipient,
+  setShowAddRecipient
+}: {
+  showAddRecipient: boolean
+  setShowAddRecipient: (value: boolean) => void
+}) {
   const [userSlippageTolerance] = useUserSlippageTolerance()
   const [multihop] = useMultihopManager()
   const theme = useContext(ThemeContext)
@@ -61,7 +67,7 @@ export function SwapSettings() {
         </StyledButton>
       </MouseoverTooltip>
       <MouseoverTooltip content={t('alternateReceiver')} placement="top">
-        <StyledButton active={!!recipient}>
+        <StyledButton active={!!recipient} cursor="pointer" onClick={() => setShowAddRecipient(!showAddRecipient)}>
           <Recipient />
         </StyledButton>
       </MouseoverTooltip>

--- a/src/components/swap/TradePrice.tsx
+++ b/src/components/swap/TradePrice.tsx
@@ -4,19 +4,14 @@ import { TYPE } from '../../theme'
 import styled from 'styled-components'
 import { transparentize } from 'polished'
 import { RowFixed } from '../Row'
-import { MouseoverTooltip } from '../Tooltip/index'
+import { useIsMobileByMedia } from '../../hooks/useIsMobileByMedia'
+import { limitDigitDecimalPlace } from '../../utils/prices'
 
 const Wrapper = styled(RowFixed)`
   background: ${props => transparentize(0.9, props.theme.bg4)};
   border-radius: 4px;
   padding: 4px 5px;
   cursor: pointer;
-`
-
-const StyledPriceText = styled(TYPE.body)`
-  overflow: hidden;
-  text-overflow: ellipsis;
-  max-width: 100px;
 `
 
 interface TradePriceProps {
@@ -26,22 +21,24 @@ interface TradePriceProps {
 }
 
 export default function TradePrice({ price, showInverted, setShowInverted }: TradePriceProps) {
-  const formattedPrice = showInverted ? price?.toSignificant(6) : price?.invert()?.toSignificant(6)
+  const isMobileByMedia = useIsMobileByMedia()
+  const significantDigits = isMobileByMedia ? 6 : 14
+  const formattedPrice = limitDigitDecimalPlace(showInverted ? price : price?.invert(), significantDigits)
 
   const show = Boolean(price?.baseCurrency && price?.quoteCurrency)
+  const quoteCurrenxy = price?.quoteCurrency.symbol?.slice(0, 4)
+  const baseCurrency = price?.baseCurrency.symbol?.slice(0, 4)
   const label = showInverted
-    ? `${price?.quoteCurrency?.symbol} per ${price?.baseCurrency?.symbol}`
-    : `${price?.baseCurrency?.symbol} per ${price?.quoteCurrency?.symbol}`
+    ? `${quoteCurrenxy} ${isMobileByMedia ? `/` : `per`} ${baseCurrency}`
+    : `${baseCurrency} ${isMobileByMedia ? `/` : `per`}  ${quoteCurrenxy}`
 
   return (
     <Wrapper onClick={() => setShowInverted(!showInverted)}>
       {show ? (
         <>
-          <MouseoverTooltip content={formattedPrice} placement="top">
-            <StyledPriceText mr="4px" fontSize="13px" lineHeight="12px" letterSpacing="0" fontWeight="700">
-              {formattedPrice ?? '-'}
-            </StyledPriceText>
-          </MouseoverTooltip>
+          <TYPE.body mr="4px" fontSize="13px" lineHeight="12px" letterSpacing="0" fontWeight="700">
+            {formattedPrice ?? '-'}
+          </TYPE.body>
           <TYPE.body fontSize="13px" lineHeight="12px" letterSpacing="0" fontWeight="500">
             {label}
           </TYPE.body>

--- a/src/components/swap/styleds.tsx
+++ b/src/components/swap/styleds.tsx
@@ -4,6 +4,7 @@ import { AlertTriangle } from 'react-feather'
 import styled from 'styled-components'
 import { Text } from 'rebass'
 import { AutoColumn } from '../Column'
+import { breakpoints } from '../../utils/theme'
 
 export const Wrapper = styled.div`
   position: relative;
@@ -33,6 +34,11 @@ export const SwitchTokensAmountsContainer = styled.div`
   border-radius: 50%;
   border: solid 5px ${props => props.theme.dark1};
   cursor: pointer;
+  @media screen and (max-width: ${breakpoints.md}) {
+    width: 42px;
+    height: 42px;
+    top: -20px;
+  }
 `
 
 export const SectionBreak = styled.div`

--- a/src/pages/Swap/index.tsx
+++ b/src/pages/Swap/index.tsx
@@ -277,6 +277,8 @@ export default function Swap() {
     fiatValueOutput
   ])
 
+  const [showAddRecipient, setShowAddRecipient] = useState<boolean>(false)
+
   return (
     <>
       <TokenWarningModal
@@ -361,7 +363,7 @@ export default function Swap() {
                       <QuestionHelper text="The trade is routed directly to the selected platform, so no swap or network fees are ever added by Swapr." />
                     </RowBetween>
                     <RowBetween>
-                      <SwapSettings />
+                      <SwapSettings showAddRecipient={showAddRecipient} setShowAddRecipient={setShowAddRecipient} />
                       <RowFixed>
                         <TradePrice
                           price={trade?.executionPrice}
@@ -372,7 +374,7 @@ export default function Swap() {
                     </RowBetween>
                   </AutoColumn>
                 )}
-                {isExpertMode && !showWrap && <RecipientField recipient={recipient} action={setRecipient} />}
+                {!showWrap && showAddRecipient && <RecipientField recipient={recipient} action={setRecipient} />}
                 <div>
                   {!account ? (
                     <ButtonConnect />

--- a/src/theme/landingPageTheme/global.css
+++ b/src/theme/landingPageTheme/global.css
@@ -1,84 +1,76 @@
 :root {
-    --main-bg-color: rgba(12, 11, 18, 1);
-    --xl-bp: 1620px;
-    --l-bp: 1360px;
-    --md-bp: 959px;
-    --s-bp: 600px;
-    --xs-bp: 416px;
+  --main-bg-color: rgba(12, 11, 18, 1);
+  --xl-bp: 1620px;
+  --l-bp: 1360px;
+  --md-bp: 959px;
+  --s-bp: 600px;
+  --xs-bp: 416px;
 }
 
 html {
-    background: var(--main-bg-color);
-    overflow-x: hidden;
-    scroll-behavior: smooth;
+  background: var(--main-bg-color);
+  overflow-x: hidden;
+  scroll-behavior: smooth;
 }
 
 body {
-    overflow-y: hidden;
-    scroll-behavior: smooth;
+  overflow-y: hidden;
+  scroll-behavior: smooth;
 }
 
 body::-webkit-scrollbar {
-    width: 10px;
-    border-left: 1px solid rgba(255,255,255,0.2);
-  }
-   
+  width: 10px;
+  border-left: 1px solid rgba(255, 255, 255, 0.2);
+}
+
 body::-webkit-scrollbar-track {
-background: transparent;
+  background: transparent;
 }
 
 body::-webkit-scrollbar-thumb {
-background-color: #B6B5B7;
-/* outline: 1px solid slategrey; */
-border-radius: 100px;
-
+  background-color: #b6b5b7;
+  /* outline: 1px solid slategrey; */
+  border-radius: 100px;
 }
 
 #___gatsby {
-    overflow: hidden;
+  overflow: hidden;
 }
 
 * {
-    color: white;
+  color: white;
 }
 
 #root {
-    color: white;
-    background: var(--main-bg-color);
+  color: white;
+  background: var(--main-bg-color);
 }
 
 .full-width {
-    width: 100%;
+  width: 100%;
 }
 
 .main-width {
-    width: 1160px;
-    margin: 0 auto;
+  width: 1160px;
+  margin: 0 auto;
 }
 
 @media screen and (max-width: 1360px) {
-    .main-width {
-        width: 1086px;
-        padding: 0;
-    }
+  .main-width {
+    width: 1086px;
+    padding: 0;
+  }
 }
 
 @media screen and (max-width: 959px) {
-    .main-width {
-        width: 543px !important;
-    }
+  .main-width {
+    width: 543px !important;
+  }
 }
 
 @media screen and (max-width: 600px) {
-    .main-width {
-        width: 100% !important;
-        padding: 0 24px;
-    }
-}
-
-@media screen and (max-width: 360px) {
-    .main-width {
-        width: 100% !important;
-        padding: 0 16px;
-    }
+  .main-width {
+    width: 100% !important;
+    padding: 0 16px;
+  }
 }

--- a/src/utils/prices.ts
+++ b/src/utils/prices.ts
@@ -183,10 +183,10 @@ export function getLpTokenPrice(
 }
 
 /**
- * Returns trimmed fraction value to significantDigits decimal places
+ * Returns trimmed fraction value to limit number of decimal places
  * @param value Fraction value to trim
- * @param significantDigits number of limit decimal places
- * @param rounding rounding mode
+ * @param significantDigits Limit number of decimal places
+ * @param rounding Rounding mode
  */
 export const limitDigitDecimalPlace = (
   value?: Fraction,

--- a/src/utils/prices.ts
+++ b/src/utils/prices.ts
@@ -122,7 +122,7 @@ export function warningSeverity(priceImpact: Percent | undefined): 0 | 1 | 2 | 3
   return NO_PRICE_IMPACT
 }
 
-export function warningFiatSeverity(priceImpact: Percent | undefined): 0 | 3 {
+export function simpleWarningSeverity(priceImpact: Percent | undefined): 0 | 3 {
   if (!priceImpact?.lessThan(ALLOWED_FIAT_PRICE_IMPACT_PERCENTAGE[PRICE_IMPACT_HIGH])) return PRICE_IMPACT_HIGH
   return NO_PRICE_IMPACT
 }
@@ -180,4 +180,21 @@ export function getLpTokenPrice(
     priceDenominator,
     parseUnits(new Decimal(reserveNativeCurrency).toFixed(nativeCurrency.decimals), nativeCurrency.decimals).toString()
   )
+}
+
+/**
+ * Returns trimmed fraction value to significantDigits decimal places
+ * @param value Fraction value to trim
+ * @param significantDigits number of limit decimal places
+ * @param rounding rounding mode
+ */
+export const limitDigitDecimalPlace = (
+  value?: Fraction,
+  significantDigits = 6,
+  rounding = Decimal.ROUND_DOWN
+): string => {
+  if (!value) return '0'
+  const fixedQuotient = value.toFixed(significantDigits)
+  Decimal.set({ precision: significantDigits + 1, rounding })
+  return new Decimal(fixedQuotient).toSignificantDigits(significantDigits).toString()
 }


### PR DESCRIPTION
- Fix css for better screen space usage
- Trim numbers to prevent overflows
- Fix add recipient UX
- Remove priceImpact and move it to exchanges table

# Summary

Closes #811

- Enhance user and mobile experience in new Swapbox, more responsive Swapbox
- Fix Recipient input UX
- Remove bottom price impact and add it to exchanges list.

![Screenshot 2022-03-29 at 10 31 10](https://user-images.githubusercontent.com/23079677/160581005-4cf3efa9-78e8-4018-b1e1-b368f9a5b61b.png)

  # To Test

1. Open the `swap` page in mobile view
- [ ] Verify if there are no overflows
2. Click in the Add Recipient icon
- [ ] Add Recipient input works accordingly 
2. Simulate trade 
- [ ] Check if Price impact is exchanges list
- [ ] Check if Price impact isn't below exchanges list


