### PR TITLE
fix black bar on gnosis

### DIFF
--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -42,6 +42,7 @@ const HeaderFrame = styled.div`
     width: calc(100%);
     position: relative;
   `};
+  max-height: 100px;
 `
 
 const HeaderControls = styled.div<{ isConnected: boolean }>`


### PR DESCRIPTION
Closes #818 
# Summary

Previously when selected Gnosis chain on top was black bar. 

### Before:
![image](https://user-images.githubusercontent.com/46563377/160589110-4c2e168c-cfa0-40e1-90c0-a5cf7c02dbe5.png)
### After:
![image](https://user-images.githubusercontent.com/46563377/160589233-17de1ed9-2d39-470e-88bc-7491f57ca8bb.png)

# To Test
1. Open the `Swapr`
- [ ] Select Ethereum Chain
- [ ] Select Gnosis Chain
