### PR TITLE
[Feature] EcoRouter show more markets button

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -118,5 +118,6 @@
   "pImpact": "P. impact",
   "pImp": "P. Imp.",
   "minReceived": "Min. Received",
-  "maxSent": "Max Sent"
+  "maxSent": "Max Sent",
+  "showMore": "Show more"
 }

--- a/src/components/swap/SwapPlatformSelector.tsx
+++ b/src/components/swap/SwapPlatformSelector.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext } from 'react'
+import React, { useCallback, useContext, useState } from 'react'
 import { CurrencyAmount, Percent, RoutablePlatform, Trade, TradeType } from '@swapr/sdk'
 import { AutoColumn } from '../Column'
 import { TYPE } from '../../theme'
@@ -32,6 +32,7 @@ import { ONE_BIPS, PRICE_IMPACT_MEDIUM, ROUTABLE_PLATFORM_LOGO } from '../../con
 import styled, { ThemeContext } from 'styled-components'
 import { useTranslation } from 'react-i18next'
 import { useIsMobileByMedia } from '../../hooks/useIsMobileByMedia'
+import { ChevronsDown } from 'react-feather'
 
 export interface SwapPlatformSelectorProps {
   allPlatformTrades: (Trade | undefined)[] | undefined
@@ -55,6 +56,11 @@ const StyledRouteFlex = styled(Flex)`
   border-radius: 12px;
   padding: 18px 16px;
   margin-bottom: 16px;
+`
+
+const MoreMarketsButton = styled(Flex)`
+  cursor: pointer;
+  text-transform: uppercase;
 `
 
 function GasFee({ loading, gasFeeUSD }: GasFeeProps) {
@@ -92,6 +98,7 @@ export function SwapPlatformSelector({
   const { t } = useTranslation()
   const theme = useContext(ThemeContext)
 
+  const [showAllPlatformsTrades, setShowAllPlatformsTrades] = useState(false)
   const [allowedSlippage] = useUserSlippageTolerance()
   const { recipient, independentField } = useSwapState()
   const { loading: loadingTradesGasEstimates, estimations } = useSwapsGasEstimations(
@@ -115,6 +122,8 @@ export function SwapPlatformSelector({
     },
     [allPlatformTrades, onSelectedPlatformChange]
   )
+
+  const displayedPlatformTrade = showAllPlatformsTrades ? allPlatformTrades : allPlatformTrades?.slice(0, 3)
 
   return (
     <AutoColumn>
@@ -141,7 +150,7 @@ export function SwapPlatformSelector({
           </SelectionListLabel>
         </SelectionListLabelWrapper>
 
-        {allPlatformTrades?.map((trade, i) => {
+        {displayedPlatformTrade?.map((trade, i) => {
           if (!trade) return null // some platforms might not be compatible with the currently selected network
           const isExactIn = trade.tradeType === TradeType.EXACT_INPUT
           const gasFeeUSD = gasFeesUSD[i]
@@ -190,6 +199,18 @@ export function SwapPlatformSelector({
           )
         })}
       </SelectionListWindowWrapper>
+      {allPlatformTrades && allPlatformTrades.length > 3 && (
+        <Flex justifyContent="center">
+          {!showAllPlatformsTrades && (
+            <MoreMarketsButton alignItems="center" onClick={() => setShowAllPlatformsTrades(true)}>
+              <TYPE.main fontWeight={600} color={'purple3'} fontSize="10px" mr="8px">
+                {t('showMore')}
+              </TYPE.main>
+              <ChevronsDown size={15} color={theme.purple3} />
+            </MoreMarketsButton>
+          )}
+        </Flex>
+      )}
     </AutoColumn>
   )
 }

--- a/src/components/swap/SwapPlatformSelector.tsx
+++ b/src/components/swap/SwapPlatformSelector.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext, useState } from 'react'
+import React, { useCallback, useContext, useEffect, useState } from 'react'
 import { CurrencyAmount, Percent, RoutablePlatform, Trade, TradeType } from '@swapr/sdk'
 import { AutoColumn } from '../Column'
 import { TYPE } from '../../theme'
@@ -111,6 +111,10 @@ export function SwapPlatformSelector({
   )
   const loadingGasFees = loadingGasFeesUSD || loadingTradesGasEstimates
   const debouncedLoadingGasFees = useDebounce(loadingGasFees, 2000)
+
+  useEffect(() => {
+    setShowAllPlatformsTrades(false)
+  }, [allPlatformTrades])
 
   const showGasFees = estimations.length === allPlatformTrades?.length
 

--- a/src/components/swap/SwapPlatformSelector.tsx
+++ b/src/components/swap/SwapPlatformSelector.tsx
@@ -129,9 +129,11 @@ export function SwapPlatformSelector({
     <AutoColumn>
       {selectedTrade && selectedTrade.route.path.length > 2 && (
         <StyledRouteFlex>
-          <TYPE.body fontSize="14px" lineHeight="15px" fontWeight="400" minWidth="auto" color={theme.purple2}>
-            Route
-          </TYPE.body>
+          {!isMobileByMedia && (
+            <TYPE.body fontSize="14px" lineHeight="15px" fontWeight="400" minWidth="auto" color={theme.purple2}>
+              Route
+            </TYPE.body>
+          )}
           <Box flex="1">
             <SwapRoute trade={selectedTrade} />
           </Box>

--- a/src/components/swap/SwapRoute.tsx
+++ b/src/components/swap/SwapRoute.tsx
@@ -5,6 +5,7 @@ import { Flex } from 'rebass'
 import styled, { ThemeContext } from 'styled-components'
 import { TYPE } from '../../theme'
 import CurrencyLogo from '../CurrencyLogo'
+import { useIsMobileByMedia } from '../../hooks/useIsMobileByMedia'
 
 const StyledChevronRight = styled(ChevronRight)`
   height: 17px;
@@ -13,15 +14,23 @@ const StyledChevronRight = styled(ChevronRight)`
 
 export default memo(function SwapRoute({ trade }: { trade: Trade }) {
   const theme = useContext(ThemeContext)
+  const isMobileByMedia = useIsMobileByMedia()
+
   return (
-    <Flex width="100%" justifyContent="flex-end" alignItems="center">
+    <Flex width="100%" justifyContent={isMobileByMedia ? 'center' : 'flex-end'} alignItems="center">
       {trade.route.path.map((token, i, path) => {
         const isLastItem: boolean = i === path.length - 1
         return (
           <Fragment key={i}>
             <Flex alignItems="center">
-              <CurrencyLogo currency={token} size="20px" />
-              <TYPE.black fontSize="14px" lineHeight="17px" fontWeight="600" color={theme.text1} ml="6px">
+              <CurrencyLogo currency={token} size={isMobileByMedia ? '16px' : '20px'} />
+              <TYPE.black
+                fontSize={isMobileByMedia ? '12px' : '14px'}
+                lineHeight="17px"
+                fontWeight="600"
+                color={theme.text1}
+                ml="6px"
+              >
                 {token.symbol}
               </TYPE.black>
             </Flex>


### PR DESCRIPTION
# Summary

Closes #643

Add EcoRouter platform list show more markets button.

<img width="457" alt="Screenshot 2022-04-04 at 13 24 06" src="https://user-images.githubusercontent.com/23079677/161542902-69b2d27b-17f1-49d9-a94d-5fb133a39f7e.png">

  # To Test

1. Open the page `swap`
2. Choose a trading pair with more than 3  available markets
- [ ] Shows only 3 markets
- [ ] Shows button "Show more"
3. Click in "Show more"
- [ ] Should show every market
- [ ] Button disappears

