### PR TITLE
Fix showing avatar empty space on accounts with ENS but no image attached

### DIFF
--- a/src/components/Web3Status/AccountStatus.tsx
+++ b/src/components/Web3Status/AccountStatus.tsx
@@ -175,7 +175,6 @@ export function AccountStatus({
           ) : ENSName ? (
             <>
               {avatar?.image && <Avatar url={avatar.image} />}
-
               <p>{ENSName}</p>
             </>
           ) : (

--- a/src/components/Web3Status/AccountStatus.tsx
+++ b/src/components/Web3Status/AccountStatus.tsx
@@ -174,8 +174,9 @@ export function AccountStatus({
             </RowBetween>
           ) : ENSName ? (
             <>
-              {avatar && <Avatar url={avatar.image} />}
-              <>{ENSName}</>
+              {avatar?.image && <Avatar url={avatar.image} />}
+
+              <p>{ENSName}</p>
             </>
           ) : (
             <>


### PR DESCRIPTION
# Summary

Closes #824

This PR fixes showing extra empty space on accounts with ENS without image attached.

**Current**
<img width="947" alt="image" src="https://user-images.githubusercontent.com/5664434/162479957-cdb4f19f-c02e-4550-8c83-9c5d69273328.png">
**Old**
<img width="941" alt="image" src="https://user-images.githubusercontent.com/5664434/162480756-ef2c679c-9a6d-4515-b773-27de98aa6cc1.png">


  # To Test

1. Open swapr app
	  - [ ] Connect to an ETH account with ENS and without avatar attached
	  - [ ] Check there isn't any empty space at the left.

