### PR TITLE
Fix connect wallet button not opening the wallet switcher modal

### DIFF
--- a/src/pages/AddLiquidity/index.tsx
+++ b/src/pages/AddLiquidity/index.tsx
@@ -21,7 +21,7 @@ import { useActiveWeb3React } from '../../hooks'
 import { useCurrency } from '../../hooks/Tokens'
 import { ApprovalState, useApproveCallback } from '../../hooks/useApproveCallback'
 import useTransactionDeadline from '../../hooks/useTransactionDeadline'
-import { useWalletModalToggle } from '../../state/application/hooks'
+import { useWalletSwitcherPopoverToggle } from '../../state/application/hooks'
 import { Field } from '../../state/mint/actions'
 import { useDerivedMintInfo, useMintActionHandlers, useMintState } from '../../state/mint/hooks'
 
@@ -61,7 +61,7 @@ export default function AddLiquidity({
         (currencyB && currencyEquals(currencyB, nativeCurrencyWrapper)))
   )
 
-  const toggleWalletModal = useWalletModalToggle() // toggle wallet when disconnected
+  const toggleWalletModal = useWalletSwitcherPopoverToggle() // toggle wallet when disconnected
 
   const expertMode = useIsExpertMode()
 

--- a/src/pages/RemoveLiquidity/index.tsx
+++ b/src/pages/RemoveLiquidity/index.tsx
@@ -40,7 +40,7 @@ import { Dots } from '../../components/swap/styleds'
 import { useBurnActionHandlers } from '../../state/burn/hooks'
 import { useDerivedBurnInfo, useBurnState } from '../../state/burn/hooks'
 import { Field } from '../../state/burn/actions'
-import { useWalletModalToggle } from '../../state/application/hooks'
+import { useWalletSwitcherPopoverToggle } from '../../state/application/hooks'
 import { useUserSlippageTolerance } from '../../state/user/hooks'
 import { BigNumber } from '@ethersproject/bignumber'
 import { calculateProtocolFee } from '../../utils/prices'
@@ -71,7 +71,7 @@ export default function RemoveLiquidity({
   const theme = useContext(ThemeContext)
 
   // toggle wallet when disconnected
-  const toggleWalletModal = useWalletModalToggle()
+  const toggleWalletModal = useWalletSwitcherPopoverToggle()
 
   // burn state
   const { independentField, typedValue } = useBurnState()

--- a/src/state/application/actions.ts
+++ b/src/state/application/actions.ts
@@ -20,7 +20,6 @@ export type PopupContent =
     }
 
 export enum ApplicationModal {
-  WALLET,
   SETTINGS,
   SELF_CLAIM,
   ADDRESS_CLAIM,

--- a/src/state/application/hooks.tsx
+++ b/src/state/application/hooks.tsx
@@ -37,10 +37,6 @@ export function useCloseModals(): () => void {
   return useCallback(() => dispatch(setOpenModal(null)), [dispatch])
 }
 
-export function useWalletModalToggle(): () => void {
-  return useToggleModal(ApplicationModal.WALLET)
-}
-
 export function useToggleSettingsMenu(): () => void {
   return useToggleModal(ApplicationModal.SETTINGS)
 }

--- a/src/state/application/reducer.test.ts
+++ b/src/state/application/reducer.test.ts
@@ -17,11 +17,11 @@ describe('application reducer', () => {
   })
 
   describe('setOpenModal', () => {
-    it('set wallet modal', () => {
-      store.dispatch(setOpenModal(ApplicationModal.WALLET))
-      expect(store.getState().openModal).toEqual(ApplicationModal.WALLET)
-      store.dispatch(setOpenModal(ApplicationModal.WALLET))
-      expect(store.getState().openModal).toEqual(ApplicationModal.WALLET)
+    it('set wallet switcher modal', () => {
+      store.dispatch(setOpenModal(ApplicationModal.WALLET_SWITCHER))
+      expect(store.getState().openModal).toEqual(ApplicationModal.WALLET_SWITCHER)
+      store.dispatch(setOpenModal(ApplicationModal.WALLET_SWITCHER))
+      expect(store.getState().openModal).toEqual(ApplicationModal.WALLET_SWITCHER)
       store.dispatch(setOpenModal(ApplicationModal.CLAIM_POPUP))
       expect(store.getState().openModal).toEqual(ApplicationModal.CLAIM_POPUP)
       store.dispatch(setOpenModal(null))


### PR DESCRIPTION
# Summary

Fixes #872 

Fix connect wallet button not opening the wallet switcher modal.

**Now**
![c3dd594d8b202f199a78134c5905205c](https://user-images.githubusercontent.com/5664434/163174089-4ed65b76-c294-49f1-8642-cbd6521494c0.gif)


# To Test

1. Open the page `liquidity` with wallet not connected
- [ ] Click on create a pair
- [ ] Click on "connect wallet"
- [ ] Should display wallet popup switcher