### PR TITLE
[Feautre] Add max balance to output token

### DIFF
--- a/src/pages/Swap/index.tsx
+++ b/src/pages/Swap/index.tsx
@@ -200,7 +200,7 @@ export default function Swap() {
   }, [approval, approvalSubmitted])
 
   const maxAmountInput: CurrencyAmount | undefined = maxAmountSpend(currencyBalances[Field.INPUT], chainId)
-  const maxAmountOutput: CurrencyAmount | undefined = maxAmountSpend(currencyBalances[Field.OUTPUT], chainId)
+  const maxAmountOutput: CurrencyAmount | undefined = maxAmountSpend(currencyBalances[Field.OUTPUT], chainId, false)
 
   // the callback to execute the swap
   const { callback: swapCallback, error: swapCallbackError } = useSwapCallback(trade, allowedSlippage, recipient)

--- a/src/pages/Swap/index.tsx
+++ b/src/pages/Swap/index.tsx
@@ -200,6 +200,7 @@ export default function Swap() {
   }, [approval, approvalSubmitted])
 
   const maxAmountInput: CurrencyAmount | undefined = maxAmountSpend(currencyBalances[Field.INPUT], chainId)
+  const maxAmountOutput: CurrencyAmount | undefined = maxAmountSpend(currencyBalances[Field.OUTPUT], chainId)
 
   // the callback to execute the swap
   const { callback: swapCallback, error: swapCallbackError } = useSwapCallback(trade, allowedSlippage, recipient)
@@ -266,9 +267,13 @@ export default function Swap() {
     [onCurrencySelection]
   )
 
-  const handleMaxInput = useCallback(() => {
-    maxAmountInput && onUserInput(Field.INPUT, maxAmountInput.toExact())
-  }, [maxAmountInput, onUserInput])
+  const handleMaxInput = useCallback(
+    fieldInput => () => {
+      maxAmountInput && fieldInput === Field.INPUT && onUserInput(Field.INPUT, maxAmountInput.toExact())
+      maxAmountOutput && fieldInput === Field.OUTPUT && onUserInput(Field.OUTPUT, maxAmountOutput.toExact())
+    },
+    [maxAmountInput, maxAmountOutput, onUserInput]
+  )
 
   const handleOutputSelect = useCallback(
     outputCurrency => {
@@ -324,7 +329,7 @@ export default function Swap() {
                     value={formattedAmounts[Field.INPUT]}
                     currency={currencies[Field.INPUT]}
                     onUserInput={handleTypeInput}
-                    onMax={handleMaxInput}
+                    onMax={handleMaxInput(Field.INPUT)}
                     onCurrencySelect={handleInputSelect}
                     otherCurrency={currencies[Field.OUTPUT]}
                     fiatValue={fiatValueInput}
@@ -346,6 +351,7 @@ export default function Swap() {
                   <CurrencyInputPanel
                     value={formattedAmounts[Field.OUTPUT]}
                     onUserInput={handleTypeOutput}
+                    onMax={handleMaxInput(Field.OUTPUT)}
                     currency={currencies[Field.OUTPUT]}
                     onCurrencySelect={handleOutputSelect}
                     otherCurrency={currencies[Field.INPUT]}

--- a/src/utils/maxAmountSpend.ts
+++ b/src/utils/maxAmountSpend.ts
@@ -5,9 +5,13 @@ import { MIN_ETH } from '../constants'
  * Given some token amount, return the max that can be spent of it
  * @param currencyAmount to return max of
  */
-export function maxAmountSpend(currencyAmount?: CurrencyAmount, chainId?: number): CurrencyAmount | undefined {
+export function maxAmountSpend(
+  currencyAmount?: CurrencyAmount,
+  chainId?: number,
+  minimumETHLeft = true
+): CurrencyAmount | undefined {
   if (!currencyAmount || !chainId) return undefined
-  if (currencyAmount.currency === ETHER) {
+  if (currencyAmount.currency === ETHER && minimumETHLeft) {
     if (JSBI.greaterThan(currencyAmount.raw, MIN_ETH)) {
       return CurrencyAmount.nativeCurrency(JSBI.subtract(currencyAmount.raw, MIN_ETH), chainId)
     } else {


### PR DESCRIPTION
# Summary

Add max balance to output token when clicking on balance.

https://user-images.githubusercontent.com/23079677/163380387-1133127c-9c0b-449a-be26-e7fb0460f66b.mp4

# To Test

1.  Open the page `swap`
2. Simulate trade
3. Click in output token max balance
- [ ] Verify the output field is filled with the max balance amount

