### PR TITLE
fix: hide unsupported net popup

### DIFF
--- a/src/components/Web3Status/index.tsx
+++ b/src/components/Web3Status/index.tsx
@@ -13,6 +13,7 @@ import { AccountStatus } from './AccountStatus'
 import { WalletConnectConnector } from '@web3-react/walletconnect-connector'
 import NetworkSwitcherPopover from '../NetworkSwitcherPopover'
 import {
+  useCloseModals,
   useModalOpen,
   useNetworkSwitcherPopoverToggle,
   useOpenModal,
@@ -122,6 +123,7 @@ export default function Web3Status() {
   const mobileByMedia = useIsMobileByMedia()
   const [isUnsupportedNetwork, setUnsupportedNetwork] = useState(false)
   const isUnsupportedNetworkModal = useModalOpen(ApplicationModal.UNSUPPORTED_NETWORK)
+  const closeModals = useCloseModals()
 
   const unsupportedChainIdError = useUnsupportedChainIdError()
 
@@ -131,8 +133,16 @@ export default function Web3Status() {
       openUnsupportedNetworkModal()
     } else if (!isUnsupportedNetworkModal && isUnsupportedNetwork && !unsupportedChainIdError) {
       setUnsupportedNetwork(false)
+    } else if (isUnsupportedNetworkModal && !unsupportedChainIdError) {
+      closeModals()
     }
-  }, [isUnsupportedNetwork, openUnsupportedNetworkModal, isUnsupportedNetworkModal, unsupportedChainIdError])
+  }, [
+    isUnsupportedNetwork,
+    openUnsupportedNetworkModal,
+    isUnsupportedNetworkModal,
+    unsupportedChainIdError,
+    closeModals
+  ])
 
   const clickHandler = useCallback(() => {
     toggleNetworkSwitcherPopover()


### PR DESCRIPTION
# Summary

Fixes #897 

Unsupported network popup should close after switch to supported via metamask

  # To Test

1. Open app and connect with MetaMask
2. Switch to unsupported network
3. Popup appears and asks for switching network 
4. Switch network **with MetaMask**
5. Popup should be closed after succesful connection with supported network


