### PR TITLE
[liquidity redesign] Add space background image to liquidity page

### DIFF
--- a/src/components/SpaceBg/index.js
+++ b/src/components/SpaceBg/index.js
@@ -1,0 +1,266 @@
+import React from 'react'
+import styled, { keyframes } from 'styled-components'
+
+import HeroImage from '../../assets/images/hero-graphic-desktop.png'
+import HeroImageLeft from '../../assets/images/hero-graphic-left.png'
+import { breakpoints, gradients } from '../../utils/theme'
+
+export const SpaceBg = ({ children }) => (
+  <StyledHero id="liquidity-hero" className="hero-active">
+    <div className="inner-hero">
+      <AppBodyContainer>{children}</AppBodyContainer>
+      <div className="hero-background">
+        <div className="hero-image hero-image-right"></div>
+        <div className="hero-image hero-image-left"></div>
+      </div>
+    </div>
+  </StyledHero>
+)
+
+const AppBodyContainer = styled.section`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  z-index: 3;
+  min-height: calc(100vh - 340px);
+`
+
+const zoomOut = keyframes`
+    0% {transform: scale(1.2); opacity: 0;}
+    100% {transform: scale(1); opacity: 0.7;}
+`
+
+const StyledHero = styled.div`
+    position: relative;
+    padding-bottom: 120px;
+    width: calc(100% + 32px) !important;
+    .inner-hero {
+        display: flex;
+        flex-direction: column;
+        min-height: calc(100vh - 240px);
+        width: 100%;
+    }
+    &:not(.hero-active) {
+        .hero-image-left,
+        .hero-image-right {
+            opacity: 0;
+        }
+        .hero-image-right {
+            transform: translateY(-100px);
+        }
+        .hero-image-left {
+            transform: translateY(-30px);
+        }
+    }
+    .hero-content {
+        padding: 0 144px;
+        margin-top: 80px;
+        position: relative;
+        z-index: 4;
+        h1 {
+            width: 665px;
+            span {
+                font-size: 61px;
+                font-weight: 600;
+                background: ${gradients.heroMainText};
+                -webkit-background-clip: text;
+                -webkit-text-fill-color: transparent;
+                line-height: 74px;
+                br {
+                    display: none;
+                }
+            }
+        }
+        .hero-logos-list {
+            margin-top: 65px;
+            display: flex;
+            align-items: center;
+            position: relative;
+            z-index: 3;
+            .hero-logo-group {
+                display: flex;
+                align-items: center;
+                li {
+                    margin-right: 31px;
+                    opacity: 0.7;
+                }
+            }
+        }
+        .hero-button-list {
+            display: flex;
+            margin-top: 65px;
+            li {
+                margin-right: 40px;
+            }
+        }
+    }
+    .hero-background {
+        animation: ${zoomOut} 500ms 1750ms ease-out forwards;
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        opacity: 0;
+        z-index: 2;
+    }
+    .hero-image-left,
+    .hero-image-right {
+        position: absolute;
+        pointer-events: none;
+        background-repeat: no-repeat;
+        background-position: right;
+        transition: 1s ease-in-out all;
+        /* transition: 0.25s ease-in-out transform; */
+    }
+    .hero-image-right {
+        background-image: url('${HeroImage}');
+        width: 1198px;
+        height: 905px;
+        top: -172px;
+        right: 0;
+        z-index: 1;
+    }
+    .hero-image-left {
+        background-image: url('${HeroImageLeft}');
+        width: 1680px;
+        height: 1680px;
+        top: -172px;
+        right: 0;
+        background-position: left top;
+        background-size: 100% auto;
+        z-index: 1;
+        @media screen and (min-width: 1680px) {
+            width: 100%;
+        }
+    }
+    
+    @media screen and (max-width: ${breakpoints.md}) {
+        .inner-hero {
+            min-height: calc(100vh + 80px);;
+        }
+        .hero-content {
+            margin-top: 42px;
+            padding: 0px;
+            h1 {
+                /* max-width: 303px; */
+                span {
+                    font-size: 48px;
+                    line-height: 54px;
+                    font-weight: 500;
+                }
+            }
+            .hero-logos-list {
+                flex-wrap: wrap;
+                margin-right: 30px;
+                margin-top: 48px;
+                flex-direction: column;
+                align-items: flex-start;
+                li {
+                    margin-bottom: 30px;
+                    img {
+                        max-width: 107px;
+                        max-height: 64px;
+                    }
+                }
+            }
+            .hero-button-list {
+                flex-wrap: wrap;
+                margin-top: 10px;
+                li {
+                    margin-bottom: 16px;
+                    .button {
+                        a {
+                            width: 163px;
+                            font-size: 10px;
+                            padding: 0;
+                            &,
+                            & .label {
+                                height: 36px;
+                                line-height: 36px;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        .routing-through {
+            &.desktop {
+                display: none;
+            }
+            &.mobile {
+                display: unset;
+            }
+            .routing-through-header {
+                .label {
+                    font-size: 12px;
+                }
+                .left-line {
+                    display: none;
+                }
+            }
+            .routing-through-body {
+                .marquee {
+                    .marquee-inner {
+                        img {
+                            margin: 0 18px;
+                        }
+                    }
+                }
+            }
+        }
+        .hero-image-right {
+            width: 1198px;
+            height: 905px;
+            top: -422px;
+            right: -340px;
+            z-index: 1;
+            opacity: 0.7;
+            transform: scale(0.8) !important;
+        }
+        .hero-image-left {
+            display: none;
+        }
+    }
+    @media screen and (max-width: ${breakpoints.s}) {
+        padding-bottom: 46px;
+        .hero-content {
+            h1 {
+                max-width: 80%;
+                span {
+                    font-size: 39px;
+                    line-height: 46.8px;
+                    font-weight: 500;
+                    br {
+                        /* display: unset; */
+                    }
+                }
+            }
+        }
+    }
+    @media screen and (max-width: 460px) {
+        .hero-content {
+            h1 {
+                br {
+                    display: unset;
+                }
+            }
+        }
+    }
+    @media not all and (min-resolution:.001dpcm)
+    { @supports (-webkit-appearance:none) {
+        .hero-content {
+            h1 {
+                color: #DFDCFD !important;
+                span {
+                    background: unset;
+                    -webkit-background-clip: unset;
+                    -webkit-text-fill-color: unset;
+                    br {
+                        display: none;
+                    }
+                }
+            }
+        }
+    }}
+`

--- a/src/pages/Pools/index.tsx
+++ b/src/pages/Pools/index.tsx
@@ -24,6 +24,7 @@ import CurrencyLogo from '../../components/CurrencyLogo'
 import { useSwaprSinglelSidedStakeCampaigns } from '../../hooks/singleSidedStakeCampaigns/useSwaprSingleSidedStakeCampaigns'
 import { Switch } from '../../components/Switch'
 import { unwrappedToken } from '../../utils/wrappedCurrency'
+import { SpaceBg } from '../../components/SpaceBg'
 
 const TitleRow = styled(RowBetween)`
   ${({ theme }) => theme.mediaWidth.upToSmall`
@@ -102,16 +103,6 @@ function Title({
     <>
       <TitleRow style={{ marginTop: '1rem' }} padding={'0'}>
         <Flex alignItems="center" justifyContent="space-between">
-          <Box mr="8px">
-            <Text fontSize="26px" lineHeight="32px">
-              Pairs
-            </Text>
-          </Box>
-          <Box mr="8px">
-            <Text fontSize="26px" lineHeight="32px">
-              /
-            </Text>
-          </Box>
           {aggregatedDataFilter === PairsFilterType.MY ? (
             <Box>
               <TYPE.mediumHeader fontWeight="400" fontSize="26px" lineHeight="32px">
@@ -149,7 +140,7 @@ function Title({
           <TransperentButton as={Link} to="/create">
             <Plus size="16" />
             <Text marginLeft="5px" fontWeight="500" fontSize="12px" data-testid="create-pair">
-              CREATE PAIR
+              ADD LIQUIDITY
             </Text>
           </TransperentButton>
         </Flex>
@@ -204,7 +195,7 @@ export default function Pools() {
   }, [])
 
   return (
-    <>
+    <SpaceBg>
       <PageWrapper>
         <SwapPoolTabs active={'pool'} />
         <AutoColumn gap="lg" justify="center">
@@ -264,6 +255,6 @@ export default function Pools() {
           </CardSection>
         </VoteCard> */}
       </PageWrapper>
-    </>
+    </SpaceBg>
   )
 }


### PR DESCRIPTION
### WIP 
_Me and @berteotti are working on updating the design of liquidity page and also the fonts and colors._

This is **work in progress** it's not finished, but we want to divide the work in smaller chunks and do things incrementally. 

We will do this smaller PRs and merge it on a "main" branch -> `feature/fonts-and-colors-liquidity-page`.

--- 

## Description

Add space background image to liquidity

<img width="1895" alt="image" src="https://user-images.githubusercontent.com/5664434/164234186-a9f4bf04-3bba-44ef-b594-3faa5d267aa5.png">

## Test

1. go to liquitidy page
- check there is the space background image