### PR TITLE
[Fix] Remove white text color CSS

### DIFF
--- a/src/theme/landingPageTheme/global.css
+++ b/src/theme/landingPageTheme/global.css
@@ -37,10 +37,6 @@ body::-webkit-scrollbar-thumb {
   overflow: hidden;
 }
 
-* {
-  color: white;
-}
-
 #root {
   color: white;
   background: var(--main-bg-color);


### PR DESCRIPTION
# Summary

Remove white text color CSS which is overriding some text colors.

![Screenshot 2022-04-26 at 10 26 51](https://user-images.githubusercontent.com/23079677/165268804-8350e258-ba0d-4b9b-b20b-e633baa5af5b.png)

  # To Test

1. Open the page `swap`
- [ ] Verify colors are consistent with design