### PR TITLE
[Fix] ecoBridge - added placeholder text on history tab

### DIFF
--- a/src/pages/Bridge/index.tsx
+++ b/src/pages/Bridge/index.tsx
@@ -79,6 +79,12 @@ const AssetWrapper = styled.div`
   flex: 1 0 35%;
 `
 
+const HistoryMessage = styled(Title)`
+  font-size: 16px;
+  font-weight: 300;
+  margin: 5px;
+`
+
 export default function Bridge() {
   const dispatch = useDispatch()
   const { chainId, account } = useActiveWeb3React()
@@ -233,7 +239,7 @@ export default function Bridge() {
         handleTriggerCollect={handleTriggerCollect}
         firstTxnToCollect={collectableTx}
       />
-      {activeTab !== 'history' && (
+      {activeTab !== BridgeTab.HISTORY && (
         <AppBody>
           <RowBetween mb="12px">
             <Title>{isCollecting ? 'Collect' : 'Swapr Bridge'}</Title>
@@ -312,9 +318,12 @@ export default function Bridge() {
           />
         </AppBody>
       )}
-      {activeTab === 'bridge' && showAvailableBridges && <BridgeSelectionWindow />}
+      {activeTab === BridgeTab.BRIDGE && showAvailableBridges && <BridgeSelectionWindow />}
       {!!bridgeSummaries.length && (
         <BridgeTransactionsSummary transactions={bridgeSummaries} handleTriggerCollect={handleTriggerCollect} />
+      )}
+      {activeTab === BridgeTab.HISTORY && !bridgeSummaries.length && (
+        <HistoryMessage>Your bridge transactions will appear here.</HistoryMessage>
       )}
       <BridgeModal
         handleResetBridge={handleResetBridge}


### PR DESCRIPTION
# Summary

Closes #871  

Add placeholder text on history tab

![image](https://user-images.githubusercontent.com/46563377/165706976-1a332408-b0dd-4f99-b73e-71d2af3d9b2c.png)

# To Test
### Open the page `Bridge`
- [ ] Open `History` tab if you don't have any transaction you should see text `Your bridge transactions will appear here.`
- [ ] Back to `Bridge`
- [ ] Make a transaction
- [ ] Back to `History` tab and you should see transaction details

