### PR TITLE
[FIX] walletconnect font size

### DIFF
--- a/src/theme/index.tsx
+++ b/src/theme/index.tsx
@@ -416,6 +416,10 @@ body {
     background: ${props => props.theme.bg1} !important;
 }
 
+.walletconnect-connect__button__text {
+  font-size: inherit !important;
+}
+
 @media only screen and (max-width: 600px) {
 	.Toastify__toast-container--top-right {
 	    top: auto !important;
@@ -427,6 +431,10 @@ body {
   .Toastify__toast-container {
 	    width: auto !important;
 	}
+
+  .walletconnect-connect__button__text {
+    font-size: 10px !important;
+  }
 }
 
 .rc-pagination-simple-pager {


### PR DESCRIPTION
# Summary
 Fixed font size on WalletConnect modal 

### Before
![image](https://user-images.githubusercontent.com/46563377/165945795-af600737-e816-4ea4-bda0-7b394186e5b0.png)
### After
![image](https://user-images.githubusercontent.com/46563377/165945838-48895822-e518-48f4-bfb0-52143ff63cf4.png)


# To Test

1. Open the `Swapr`
- [ ] Click `Change Wallet`
- [ ] Select `WALLETCONNECT`
- [ ] Select `Desktop` tab
- [ ] Font size should be correct and fits to window width 
