### PR TITLE
CSS fix to wallet connect desktop font size

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "ws": "^7.4.6"
   },
   "scripts": {
-    "start": "react-scripts start",
+    "start": "yarn && react-scripts start",
     "build": "cross-env GENERATE_SOURCEMAP=false react-app-rewired build",
     "ipfs-build": "cross-env PUBLIC_URL=\".\" GENERATE_SOURCEMAP=false react-app-rewired build",
     "test": "react-scripts test --env=jsdom",

--- a/src/theme/index.tsx
+++ b/src/theme/index.tsx
@@ -458,4 +458,8 @@ body {
 .walletconnect-modal__mobile__toggle a {
   color: rgb(64, 153, 255);
 }
+
+#walletconnect-wrapper .walletconnect-connect__button__text{
+  font-size: 16px !important;
+}
 `


### PR DESCRIPTION
# Summary

Fixes #821

Wallet connect font size is fixed with a css override

![Screenshot 2022-05-03 at 23 03 51](https://user-images.githubusercontent.com/102727631/166566218-b7ffec5a-ae04-4fc6-b107-98ad06af4a22.png)


  # To Test

Go to connect and choose wallet connect as wallet and font should be of 16px size


