### PR TITLE
Bugfix/926 hide unwanted single token staking loading indicator

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,12 +8,7 @@
       "jsx": true
     }
   },
-  "ignorePatterns": [
-    "node_modules/**/*",
-    "scripts/*.js",
-    "config-overrides.js",
-    "src/**/generated/**/*"
-  ],
+  "ignorePatterns": ["node_modules/**/*", "scripts/*.js", "config-overrides.js", "src/**/generated/**/*"],
   "settings": {
     "react": {
       "version": "detect"
@@ -28,6 +23,16 @@
   "rules": {
     "@typescript-eslint/explicit-function-return-type": "off",
     "@typescript-eslint/no-explicit-any": "off",
-    "react/prop-types": "off"
+    "react/prop-types": "off",
+    "@typescript-eslint/no-non-null-assertion": "off",
+    "no-unused-vars": "off",
+    "@typescript-eslint/no-unused-vars": [
+      "warn",
+      {
+        "argsIgnorePattern": "^_",
+        "varsIgnorePattern": "^_",
+        "caughtErrorsIgnorePattern": "^_"
+      }
+    ]
   }
 }

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -261,7 +261,7 @@ function Header() {
         newSwprBalance={newSwprBalance}
         stakedAmount={stakedTokenAmount?.toFixed(3)}
         singleSidedCampaignLink={
-          data && !loading ? `/rewards/single-campaign/${data.stakeToken.address}/${data.address}` : undefined
+          data && !loading ? `/rewards/single-sided-campaign/${data.stakeToken.address}/${data.address}` : undefined
         }
       />
       <HeaderRow isDark={isDark}>

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -215,9 +215,9 @@ const AdditionalDataWrap = styled.div`
   flex-direction: column;
   justify-content: end;
 `
-const StyledChevron = styled(ChevronUp)<{ isOpen: boolean }>`
+const StyledChevron = styled(ChevronUp)<{ open: boolean }>`
   stroke: ${({ theme }) => theme.orange1};
-  transform: ${({ isOpen }) => (isOpen ? 'rotate(0deg)' : 'rotate(180deg)')};
+  transform: ${({ open }) => (open ? 'rotate(0deg)' : 'rotate(180deg)')};
 `
 
 function Header() {
@@ -261,7 +261,7 @@ function Header() {
         newSwprBalance={newSwprBalance}
         stakedAmount={stakedTokenAmount?.toFixed(3)}
         singleSidedCampaignLink={
-          data && !loading ? `/rewards/${data.stakeToken.address}/${data.address}/singleSidedStaking` : undefined
+          data && !loading ? `/rewards/single-campaign/${data.stakeToken.address}/${data.address}` : undefined
         }
       />
       <HeaderRow isDark={isDark}>
@@ -332,7 +332,7 @@ function Header() {
               <Text marginLeft={'4px'} marginRight={'2px'} fontSize={10} fontWeight={600} lineHeight={'9px'}>
                 {gas.normal}
               </Text>
-              {gas.fast === 0 && gas.slow === 0 ? '' : <StyledChevron isOpen={isGasInfoOpen} size={12} />}
+              {gas.fast === 0 && gas.slow === 0 ? '' : <StyledChevron open={isGasInfoOpen} size={12} />}
             </GasInfo>
           )}
         </Flex>

--- a/src/components/LiquidityMiningCampaigns/List/index.tsx
+++ b/src/components/LiquidityMiningCampaigns/List/index.tsx
@@ -82,7 +82,7 @@ export default function List({ loading, items = [] }: LiquidityMiningCampaignsLi
                   return (
                     <UndecoratedLink
                       key={item.campaign.address}
-                      to={`/rewards/${item.campaign.stakeToken.address}/${item.campaign.address}/singleSidedStaking`}
+                      to={`/rewards/single-campaign/${item.campaign.stakeToken.address}/${item.campaign.address}`}
                     >
                       <CampaignCard
                         token0={item.campaign.stakeToken}
@@ -105,7 +105,7 @@ export default function List({ loading, items = [] }: LiquidityMiningCampaignsLi
                   return (
                     <UndecoratedLink
                       key={item.campaign.address}
-                      to={`/rewards/${token0?.address}/${token1?.address}/${item.campaign.address}`}
+                      to={`/rewards/campaign/${token0?.address}/${token1?.address}/${item.campaign.address}`}
                     >
                       <CampaignCard
                         token0={token0}

--- a/src/components/LiquidityMiningCampaigns/List/index.tsx
+++ b/src/components/LiquidityMiningCampaigns/List/index.tsx
@@ -82,7 +82,7 @@ export default function List({ loading, items = [] }: LiquidityMiningCampaignsLi
                   return (
                     <UndecoratedLink
                       key={item.campaign.address}
-                      to={`/rewards/single-campaign/${item.campaign.stakeToken.address}/${item.campaign.address}`}
+                      to={`/rewards/single-sided-campaign/${item.campaign.stakeToken.address}/${item.campaign.address}`}
                     >
                       <CampaignCard
                         token0={item.campaign.stakeToken}

--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -123,7 +123,7 @@ export default function App() {
                   <FullFeaturesRoute
                     exact
                     strict
-                    path="/rewards/single-campaign/:currencyIdA/:liquidityMiningCampaignId"
+                    path="/rewards/single-sided-campaign/:currencyIdA/:liquidityMiningCampaignId"
                     component={LiquidityMiningCampaign}
                   />
                   <FullFeaturesRoute

--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -119,17 +119,17 @@ export default function App() {
                   <FullFeaturesRoute exact strict path="/pools/mine" component={MyPairs} />
                   <FullFeaturesRoute exact strict path="/rewards" component={Rewards} />
                   <FullFeaturesRoute exact strict path="/rewards/:currencyIdA/:currencyIdB" component={Rewards} />
-                  <FullFeaturesRoute
-                    exact
-                    strict
-                    path="/rewards/:currencyIdA/:liquidityMiningCampaignId/singleSidedStaking"
-                    component={LiquidityMiningCampaign}
-                  />
                   <FullFeaturesRoute exact strict path="/pools/:currencyIdA/:currencyIdB" component={Pair} />
                   <FullFeaturesRoute
                     exact
                     strict
-                    path="/rewards/:currencyIdA/:currencyIdB/:liquidityMiningCampaignId"
+                    path="/rewards/single-campaign/:currencyIdA/:liquidityMiningCampaignId"
+                    component={LiquidityMiningCampaign}
+                  />
+                  <FullFeaturesRoute
+                    exact
+                    strict
+                    path="/rewards/campaign/:currencyIdA/:currencyIdB/:liquidityMiningCampaignId"
                     component={LiquidityMiningCampaign}
                   />
                   <FullFeaturesRoute exact strict path="/create" component={AddLiquidity} />

--- a/src/pages/Pools/LiquidityMiningCampaign/index.tsx
+++ b/src/pages/Pools/LiquidityMiningCampaign/index.tsx
@@ -49,12 +49,12 @@ export default function LiquidityMiningCampaign({
     params: { liquidityMiningCampaignId, currencyIdA, currencyIdB },
   },
   location,
-}: RouteComponentProps<{ currencyIdA: string; currencyIdB: string; liquidityMiningCampaignId: string }>) {
+}: RouteComponentProps<{ currencyIdA: string; currencyIdB?: string; liquidityMiningCampaignId: string }>) {
   const { account } = useActiveWeb3React()
 
   const token0 = useToken(currencyIdA)
   const token1 = useToken(currencyIdB)
-  const isSingleSidedCampaign = location.pathname.includes('/singleSidedStaking')
+  const isSingleSidedCampaign = location.pathname.includes('/single-campaign')
 
   const { singleSidedStakingCampaign, loading: SingleSidedCampaignLoader } = useSingleSidedCampaign(
     liquidityMiningCampaignId
@@ -74,6 +74,9 @@ export default function LiquidityMiningCampaign({
   }
   const AddLiquidityButtonComponent =
     lpTokenBalance && lpTokenBalance.equalTo('0') ? ResponsiveButtonPrimary : ResponsiveButtonSecondary
+
+  const showSingleSidedCampaignLoader = isSingleSidedCampaign && !token0
+  const showCampaignLoader = !isSingleSidedCampaign && (!token1 || !token0)
   return (
     <PageWrapper>
       <SwapPoolTabs active={'pool'} />
@@ -107,12 +110,12 @@ export default function LiquidityMiningCampaign({
               </Box>
               <Box>
                 <TYPE.small color="text4" fontWeight="600" fontSize="16px" lineHeight="20px">
-                  {!token0 || !token1 ? (
+                  {showSingleSidedCampaignLoader || showCampaignLoader ? (
                     <Skeleton width="60px" />
                   ) : isSingleSidedCampaign ? (
-                    unwrappedToken(token0)?.symbol
+                    unwrappedToken(token0!)?.symbol
                   ) : (
-                    `${unwrappedToken(token0)?.symbol}/${unwrappedToken(token1)?.symbol}`
+                    `${unwrappedToken(token0!)?.symbol}/${unwrappedToken(token1!)?.symbol}`
                   )}
                 </TYPE.small>
               </Box>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,6 @@
     "strict": true,
     "alwaysStrict": true,
     "strictNullChecks": true,
-    "noUnusedLocals": true,
     "noFallthroughCasesInSwitch": true,
     "noImplicitAny": true,
     "noImplicitThis": true,


### PR DESCRIPTION
# Summary

Fixes #926


Single staked campaign was showing loader for the second token. Since its only one token we dont want that loading.

![Screenshot 2022-05-06 at 12 08 46](https://user-images.githubusercontent.com/102727631/167112287-37a27456-12de-49f4-8279-c2f18f680c9b.png)

  # To Test

Go to rewards => swapr and should not see any loading.


  # Background

Updated tsconfig and eslint 

1. Unused variables shouldn't shop compilation, its bad developer experience since we cant comment some file for testing.
2. Should be able to ignore unused vars with _ , its useful when we want to destructure out some props
eg: `{id: _unwanted, ...rest}` and then use the rest
3. Also `@typescript-eslint/no-non-null-assertion` so can do non-null assertion with `!` if we are sure it will not be null.
 
