### PR TITLE
Fix for rewards crash

### DIFF
--- a/src/hooks/useAllLiquidtyMiningCampaigns.ts
+++ b/src/hooks/useAllLiquidtyMiningCampaigns.ts
@@ -139,7 +139,7 @@ export function useAllLiquidtyMiningCampaigns(
       singleSidedCampaignsError ||
       campaignError ||
       !singleSidedCampaigns ||
-      !singleSidedCampaigns.singleSidedStakingCampaigns ||
+      !singleSidedCampaigns?.singleSidedStakingCampaigns ||
       !pairCampaigns ||
       !pairCampaigns.liquidityMiningCampaigns ||
       loadingKpiTokens
@@ -223,14 +223,23 @@ export function useAllLiquidtyMiningCampaigns(
         campaign.stakeToken.symbol,
         campaign.stakeToken.name
       )
-      const singleSidedStakeCampaign = toSingleSidedStakeCampaign(
-        chainId,
-        campaign,
-        stakeToken,
-        campaign.stakeToken.totalSupply,
-        nativeCurrency,
-        campaign.stakeToken.derivedNativeCurrency
-      )
+
+      let singleSidedStakeCampaign
+      try {
+        singleSidedStakeCampaign = toSingleSidedStakeCampaign(
+          chainId,
+          campaign,
+          stakeToken,
+          campaign.stakeToken.totalSupply,
+          nativeCurrency,
+          campaign.stakeToken.derivedNativeCurrency
+        )
+      } catch (e) {
+        // TODO: Investigate why `derivedNativeCurrency` is zero
+        console.error('Campaign', { campaign })
+        continue
+      }
+
       const hasStake = campaign.singleSidedStakingPositions.length > 0
       const isExpired = parseInt(campaign.endsAt) < timestamp || parseInt(campaign.endsAt) > memoizedLowerTimeLimit
 


### PR DESCRIPTION
# Reason
DerivedCurrency for singleStaked campaigns are getting zero and triggering a fraction result to infinity

# Summary
Fixes #963

Now put toSingleSidedStakeCampaign in try catch and skip those campaigns with `campaign.stakeToken.derivedNativeCurrency` is `0`

  # To Test

Go to swapr in rinkeby network and go to rewards page.





