### PR TITLE
Feature/add polygon support

### DIFF
--- a/src/components/LandingPageComponents/layout/Hero.js
+++ b/src/components/LandingPageComponents/layout/Hero.js
@@ -65,6 +65,12 @@ const Hero = props => {
 
     const target = document.querySelector('#index-hero')
     observer.observe(target)
+
+    return () => {
+      if (target) {
+        observer.unobserve(target)
+      }
+    }
   }, [])
 
   useEffect(() => {

--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -1,6 +1,6 @@
 import { ApolloProvider } from '@apollo/client'
-import React, { Suspense, useContext, useEffect } from 'react'
-import { Route, Switch } from 'react-router-dom'
+import React, { FC, Suspense, useContext, useEffect } from 'react'
+import { Redirect, Route, RouteProps, Switch } from 'react-router-dom'
 import styled, { ThemeContext } from 'styled-components'
 import { defaultSubgraphClient, subgraphClients } from '../apollo/client'
 import Header from '../components/Header'
@@ -55,7 +55,7 @@ const BodyWrapper = styled.div`
   overflow: visible;
   z-index: 10;
   ${({ theme }) => theme.mediaWidth.upToSmall`
-    /* [PR#531]: theme.mediaWidth.upToSmall does not cover all the breakpoints smoothly 
+    /* [PR#531]: theme.mediaWidth.upToSmall does not cover all the breakpoints smoothly
     padding: 16px;
     */
     padding-top: 2rem;
@@ -71,6 +71,23 @@ const BodyWrapper = styled.div`
 const Marginer = styled.div`
   margin-top: 5rem;
 `
+
+interface AppRouteProps extends RouteProps {
+  isAllFeaturesEnabled: boolean
+}
+
+/**
+ * A Route that is only accessible if all features are enabled.
+ * @param param0
+ * @returns
+ */
+const FullFeaturesRoute: FC<AppRouteProps> = ({ isAllFeaturesEnabled, ...routeProps }) => {
+  if (isAllFeaturesEnabled) {
+    return <Route {...routeProps} />
+  }
+  return <Redirect to={{ ...location, pathname: '/swap' }} />
+}
+
 export default function App() {
   const { chainId } = useActiveWeb3React()
   const theme = useContext(ThemeContext)
@@ -85,6 +102,10 @@ export default function App() {
       })
     }, 1000)
   }, [])
+
+  console.log({
+    allFeaturesEnabled,
+  })
 
   return (
     <Suspense fallback={null}>
@@ -102,42 +123,113 @@ export default function App() {
                   <Route exact strict path="/swap" component={Swap} />
                   <Route exact strict path="/swap/:outputCurrency" component={RedirectToSwap} />
                   <Route exact strict path="/bridge" component={Bridge} />
+
+                  <FullFeaturesRoute
+                    isAllFeaturesEnabled={allFeaturesEnabled}
+                    exact
+                    strict
+                    path="/send"
+                    component={RedirectPathToSwapOnly}
+                  />
+                  <FullFeaturesRoute
+                    isAllFeaturesEnabled={allFeaturesEnabled}
+                    exact
+                    strict
+                    path="/pools"
+                    component={Pools}
+                  />
+                  <FullFeaturesRoute
+                    isAllFeaturesEnabled={allFeaturesEnabled}
+                    exact
+                    strict
+                    path="/pools/mine"
+                    component={MyPairs}
+                  />
+                  <FullFeaturesRoute
+                    isAllFeaturesEnabled={allFeaturesEnabled}
+                    exact
+                    strict
+                    path="/rewards"
+                    component={Rewards}
+                  />
+                  <FullFeaturesRoute
+                    isAllFeaturesEnabled={allFeaturesEnabled}
+                    exact
+                    strict
+                    path="/rewards/:currencyIdA/:currencyIdB"
+                    component={Rewards}
+                  />
+                  <FullFeaturesRoute
+                    isAllFeaturesEnabled={allFeaturesEnabled}
+                    exact
+                    strict
+                    path="/rewards/:currencyIdA/:liquidityMiningCampaignId/singleSidedStaking"
+                    component={LiquidityMiningCampaign}
+                  />
+                  <FullFeaturesRoute
+                    isAllFeaturesEnabled={allFeaturesEnabled}
+                    exact
+                    strict
+                    path="/pools/:currencyIdA/:currencyIdB"
+                    component={Pair}
+                  />
+                  <FullFeaturesRoute
+                    isAllFeaturesEnabled={allFeaturesEnabled}
+                    exact
+                    strict
+                    path="/rewards/:currencyIdA/:currencyIdB/:liquidityMiningCampaignId"
+                    component={LiquidityMiningCampaign}
+                  />
+                  <FullFeaturesRoute
+                    isAllFeaturesEnabled={allFeaturesEnabled}
+                    exact
+                    strict
+                    path="/create"
+                    component={AddLiquidity}
+                  />
+                  <FullFeaturesRoute
+                    isAllFeaturesEnabled={allFeaturesEnabled}
+                    exact
+                    path="/add"
+                    component={AddLiquidity}
+                  />
+                  {/* <Route exact strict path="/governance" component={GovPages} /> */}
+                  {/* <Route exact strict path="/governance/:asset/pairs" component={GovPages} /> */}
+                  <FullFeaturesRoute
+                    isAllFeaturesEnabled={allFeaturesEnabled}
+                    exact
+                    path="/add/:currencyIdA"
+                    component={RedirectOldAddLiquidityPathStructure}
+                  />
+                  <FullFeaturesRoute
+                    isAllFeaturesEnabled={allFeaturesEnabled}
+                    exact
+                    path="/add/:currencyIdA/:currencyIdB"
+                    component={RedirectDuplicateTokenIds}
+                  />
+                  <FullFeaturesRoute
+                    isAllFeaturesEnabled={allFeaturesEnabled}
+                    exact
+                    strict
+                    path="/remove/:tokens"
+                    component={RedirectOldRemoveLiquidityPathStructure}
+                  />
+                  <FullFeaturesRoute
+                    isAllFeaturesEnabled={allFeaturesEnabled}
+                    exact
+                    strict
+                    path="/remove/:currencyIdA/:currencyIdB"
+                    component={RemoveLiquidity}
+                  />
+                  <FullFeaturesRoute
+                    isAllFeaturesEnabled={allFeaturesEnabled}
+                    exact
+                    strict
+                    path="/liquidity-mining/create"
+                    component={CreateLiquidityMining}
+                  />
+
                   <Route component={RedirectPathToSwapOnly} />
-
-                  {allFeaturesEnabled && (
-                    <>
-                      <Route exact strict path="/send" component={RedirectPathToSwapOnly} />
-                      <Route exact strict path="/pools" component={Pools} />
-                      <Route exact strict path="/pools/mine" component={MyPairs} />
-                      <Route exact strict path="/rewards" component={Rewards} />
-                      <Route exact strict path="/rewards/:currencyIdA/:currencyIdB" component={Rewards} />
-                      <Route
-                        exact
-                        strict
-                        path="/rewards/:currencyIdA/:liquidityMiningCampaignId/singleSidedStaking"
-                        component={LiquidityMiningCampaign}
-                      />
-                      <Route exact strict path="/pools/:currencyIdA/:currencyIdB" component={Pair} />
-
-                      <Route
-                        exact
-                        strict
-                        path="/rewards/:currencyIdA/:currencyIdB/:liquidityMiningCampaignId"
-                        component={LiquidityMiningCampaign}
-                      />
-
-                      <Route exact strict path="/create" component={AddLiquidity} />
-                      <Route exact path="/add" component={AddLiquidity} />
-                      {/* <Route exact strict path="/governance" component={GovPages} /> */}
-                      {/* <Route exact strict path="/governance/:asset/pairs" component={GovPages} /> */}
-                      <Route exact path="/add/:currencyIdA" component={RedirectOldAddLiquidityPathStructure} />
-                      <Route exact path="/add/:currencyIdA/:currencyIdB" component={RedirectDuplicateTokenIds} />
-                      <Route exact strict path="/remove/:tokens" component={RedirectOldRemoveLiquidityPathStructure} />
-                      <Route exact strict path="/remove/:currencyIdA/:currencyIdB" component={RemoveLiquidity} />
-                      <Route exact strict path="/liquidity-mining/create" component={CreateLiquidityMining} />
-                      <Route component={RedirectPathToSwapOnly} />
-                    </>
-                  )}
                 </Switch>
               </Web3ReactManager>
               <Marginer />


### PR DESCRIPTION
# Summary

Closes #853

- Enabled selecting Polygon (connectors, bridge inputs, etc)
- Refactored header menu components to be cleaner
- Disabled features that require SWPR token (and/or its infrastructure) when connected to a non-SWPR network
- Added Quickswap dex 

To test:
- Polygon is visible and selectable in the Network Switcher
-`Liquidity` and `Rewards` are not disabled and can be clicked in the menu
- User is able to connect to polygon (RPC endpoint is correct)

After connectin to Polygon:
- Default currency is `MATIC` and balances are displayed correctly
- `Liquidity` and `Rewards` are grayed out in the menu and can't be clicked. Badge 'Not available' should be visible 
- Going to https://swapr.eth.link/#/pools or https://swapr.eth.link/#/rewards redirects to the landing page (routing is disabled for non-SWPR features).
- Quickswap and Sushiswap are visible on ecoRouter when some common pair is selected

