### PR TITLE
[#983] Bug-fix background image move on polygon

### DIFF
--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -42,7 +42,7 @@ const HeaderFrame = styled.div`
     width: calc(100%);
     position: relative;
   `};
-  max-height: 100px;
+  height: 100px;
 `
 
 const HeaderControls = styled.div<{ isConnected: boolean }>`


### PR DESCRIPTION
# Summary

Fixes #983
Even when not connected the gas and default token was taking space since it was `visibility: hidden` in css so the total height of the Top menu was 100px and when switch to polygon this default token was empty and the Top menu will shrink to 84px. 

Solution: Made the top bar height to 100px always.

![Screenshot 2022-05-15 at 20 24 10](https://user-images.githubusercontent.com/102727631/168488253-64cd06a6-7ed9-4aab-9cfa-3568eddbb78d.png)
![Screenshot 2022-05-15 at 20 25 06](https://user-images.githubusercontent.com/102727631/168488255-f924c063-ebe4-483d-a5fb-278f62c65f41.png)


  # To Test

#983 should pass.

