### PR TITLE
Single sided campaign dynamic token name for get button

### DIFF
--- a/src/pages/Pools/LiquidityMiningCampaign/index.tsx
+++ b/src/pages/Pools/LiquidityMiningCampaign/index.tsx
@@ -146,7 +146,7 @@ export default function LiquidityMiningCampaign({
                 }}
               >
                 <Text fontWeight={700} fontSize={12}>
-                  {isSingleSidedCampaign ? `GET ${token0?.symbol}` : 'ADD LIQUIDITY'}
+                  {isSingleSidedCampaign ? `GET ${token0?.symbol ?? 'TOKEN' }` : 'ADD LIQUIDITY'}
                 </Text>
               </AddLiquidityButtonComponent>
             </ButtonRow>

--- a/src/pages/Pools/LiquidityMiningCampaign/index.tsx
+++ b/src/pages/Pools/LiquidityMiningCampaign/index.tsx
@@ -146,7 +146,7 @@ export default function LiquidityMiningCampaign({
                 }}
               >
                 <Text fontWeight={700} fontSize={12}>
-                  {isSingleSidedCampaign ? 'GET SWPR' : 'ADD LIQUIDITY'}
+                  {isSingleSidedCampaign ? `GET ${token0?.symbol}` : 'ADD LIQUIDITY'}
                 </Text>
               </AddLiquidityButtonComponent>
             </ButtonRow>


### PR DESCRIPTION
# Summary

Fixes #869 

-button for single sided rewards used to always say get swapr now it will say token name that campaign is related to
![Screenshot 2022-05-18 at 13 41 38](https://user-images.githubusercontent.com/33226956/169030748-7bdfaff9-ce5e-4a66-9222-eb8153c0f40f.png)


  # To Test

1. Go to gnosis chain
2. go to this curv expired single sided campaign http://localhost:3000/#/rewards/single-sided-campaign/0x712b3d230F3C1c19db860d80619288b1F0BDd0Bd/0x7AbD8D2990Ac41031D968093BFEC742b35E7fdF3?chainId=100 and check that swapr single sided campaings are showing proper text as well
4. should show curve

  # Background

*Optional: Give background information for changes you've made, that might be difficult to explain via comments*

