### PR TITLE
[fix] Menu liquidity not highlighting when /add, /remove and /create

### DIFF
--- a/src/components/PositionCard/index.tsx
+++ b/src/components/PositionCard/index.tsx
@@ -303,7 +303,7 @@ export default function FullPositionCard({ pair, border }: FullPositionCardProps
             <ButtonDark
               padding="8px"
               as={Link}
-              to={currency0 && currency1 ? `/add/${currencyId(currency0)}/${currencyId(currency1)}` : ''}
+              to={currency0 && currency1 ? `/pools/add/${currencyId(currency0)}/${currencyId(currency1)}` : ''}
               style={{ fontSize: '12px', fontWeight: 'bold', lineHeight: '15px' }}
               width={showRemoveButton ? '48%' : '100%'}
             >
@@ -314,7 +314,7 @@ export default function FullPositionCard({ pair, border }: FullPositionCardProps
                 padding="8px"
                 as={Link}
                 width="48%"
-                to={currency0 && currency1 ? `/remove/${currencyId(currency0)}/${currencyId(currency1)}` : ''}
+                to={currency0 && currency1 ? `/pools/remove/${currencyId(currency0)}/${currencyId(currency1)}` : ''}
                 style={{ fontSize: '12px', fontWeight: 'bold', lineHeight: '15px' }}
               >
                 REMOVE LIQUIDITY

--- a/src/pages/AddLiquidity/index.tsx
+++ b/src/pages/AddLiquidity/index.tsx
@@ -265,9 +265,9 @@ export default function AddLiquidity({
     (currencyA: Currency) => {
       const newCurrencyIdA = currencyId(currencyA)
       if (newCurrencyIdA === currencyIdB) {
-        history.push(`/add/${currencyIdB}/${currencyIdA}`)
+        history.push(`/pools/add/${currencyIdB}/${currencyIdA}`)
       } else {
-        history.push(`/add/${newCurrencyIdA}/${currencyIdB}`)
+        history.push(`/pools/add/${newCurrencyIdA}/${currencyIdB}`)
       }
     },
     [currencyIdB, history, currencyIdA]
@@ -277,12 +277,12 @@ export default function AddLiquidity({
       const newCurrencyIdB = currencyId(currencyB)
       if (currencyIdA === newCurrencyIdB) {
         if (currencyIdB) {
-          history.push(`/add/${currencyIdB}/${newCurrencyIdB}`)
+          history.push(`/pools/add/${currencyIdB}/${newCurrencyIdB}`)
         } else {
-          history.push(`/add/${newCurrencyIdB}`)
+          history.push(`/pools/add/${newCurrencyIdB}`)
         }
       } else {
-        history.push(`/add/${currencyIdA ? currencyIdA : 'ETH'}/${newCurrencyIdB}`)
+        history.push(`/pools/add/${currencyIdA ? currencyIdA : 'ETH'}/${newCurrencyIdB}`)
       }
     },
     [currencyIdA, history, currencyIdB]

--- a/src/pages/AddLiquidity/redirects.tsx
+++ b/src/pages/AddLiquidity/redirects.tsx
@@ -3,7 +3,7 @@ import { Redirect, RouteComponentProps } from 'react-router-dom'
 import AddLiquidity from './index'
 
 export function RedirectToAddLiquidity() {
-  return <Redirect to="/add/" />
+  return <Redirect to="/pools/add/" />
 }
 
 const OLD_PATH_STRUCTURE = /^(0x[a-fA-F0-9]{40})-(0x[a-fA-F0-9]{40})$/
@@ -15,7 +15,7 @@ export function RedirectOldAddLiquidityPathStructure(props: RouteComponentProps<
   } = props
   const match = currencyIdA.match(OLD_PATH_STRUCTURE)
   if (match?.length) {
-    return <Redirect to={`/add/${match[1]}/${match[2]}`} />
+    return <Redirect to={`/pools/add/${match[1]}/${match[2]}`} />
   }
 
   return <AddLiquidity {...props} />
@@ -28,7 +28,7 @@ export function RedirectDuplicateTokenIds(props: RouteComponentProps<{ currencyI
     },
   } = props
   if (currencyIdA.toLowerCase() === currencyIdB.toLowerCase()) {
-    return <Redirect to={`/add/${currencyIdA}`} />
+    return <Redirect to={`/pools/add/${currencyIdA}`} />
   }
   return <AddLiquidity {...props} />
 }

--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -132,26 +132,30 @@ export default function App() {
                     path="/rewards/campaign/:currencyIdA/:currencyIdB/:liquidityMiningCampaignId"
                     component={LiquidityMiningCampaign}
                   />
-                  <FullFeaturesRoute exact strict path="/create" component={AddLiquidity} />
-                  <FullFeaturesRoute exact path="/add" component={AddLiquidity} />
+                  <FullFeaturesRoute exact strict path="/pools/create" component={AddLiquidity} />
+                  <FullFeaturesRoute exact path="/pools/add" component={AddLiquidity} />
                   {/* <Route exact strict path="/governance" component={GovPages} /> */}
                   {/* <Route exact strict path="/governance/:asset/pairs" component={GovPages} /> */}
-                  <FullFeaturesRoute exact path="/add/:currencyIdA" component={RedirectOldAddLiquidityPathStructure} />
                   <FullFeaturesRoute
                     exact
-                    path="/add/:currencyIdA/:currencyIdB"
+                    path="/pools/add/:currencyIdA"
+                    component={RedirectOldAddLiquidityPathStructure}
+                  />
+                  <FullFeaturesRoute
+                    exact
+                    path="/pools/add/:currencyIdA/:currencyIdB"
                     component={RedirectDuplicateTokenIds}
                   />
                   <FullFeaturesRoute
                     exact
                     strict
-                    path="/remove/:tokens"
+                    path="/pools/remove/:tokens"
                     component={RedirectOldRemoveLiquidityPathStructure}
                   />
                   <FullFeaturesRoute
                     exact
                     strict
-                    path="/remove/:currencyIdA/:currencyIdB"
+                    path="/pools/remove/:currencyIdA/:currencyIdB"
                     component={RemoveLiquidity}
                   />
                   <FullFeaturesRoute exact strict path="/liquidity-mining/create" component={CreateLiquidityMining} />

--- a/src/pages/Pools/LiquidityMiningCampaign/index.tsx
+++ b/src/pages/Pools/LiquidityMiningCampaign/index.tsx
@@ -138,7 +138,7 @@ export default function LiquidityMiningCampaign({
                   if (token0 && token1) {
                     return {
                       ...location,
-                      pathname: `/add/${currencyId(token0)}/${currencyId(token1)}`,
+                      pathname: `/pools/add/${currencyId(token0)}/${currencyId(token1)}`,
                     }
                   }
 

--- a/src/pages/Pools/Mine/index.tsx
+++ b/src/pages/Pools/Mine/index.tsx
@@ -77,7 +77,7 @@ export default function MyPairs() {
               </Box>
             </Flex>
             <ButtonRow>
-              <ResponsiveButtonPrimary id="join-pool-button" as={Link} padding="8px 14px" to="/create">
+              <ResponsiveButtonPrimary id="join-pool-button" as={Link} padding="8px 14px" to="/pools/create">
                 <Text fontWeight={700} fontSize={12}>
                   CREATE PAIR
                 </Text>

--- a/src/pages/Pools/Pair/index.tsx
+++ b/src/pages/Pools/Pair/index.tsx
@@ -142,7 +142,7 @@ export default function Pair({
                 </PointableFlex>
               </Flex>
               <ButtonRow>
-                <ResponsiveButtonPrimary id="join-pool-button" as={Link} padding="8px 14px" to="/create">
+                <ResponsiveButtonPrimary id="join-pool-button" as={Link} padding="8px 14px" to="/pools/create">
                   <Text fontWeight={700} fontSize={12}>
                     CREATE PAIR
                   </Text>

--- a/src/pages/Pools/index.tsx
+++ b/src/pages/Pools/index.tsx
@@ -146,7 +146,7 @@ function Title({
             </PointableFlex>
           )}
 
-          <TransperentButton as={Link} to="/create">
+          <TransperentButton as={Link} to="/pools/create">
             <Plus size="16" />
             <Text marginLeft="5px" fontWeight="500" fontSize="12px" data-testid="create-pair">
               CREATE PAIR

--- a/src/pages/RemoveLiquidity/index.tsx
+++ b/src/pages/RemoveLiquidity/index.tsx
@@ -452,9 +452,9 @@ export default function RemoveLiquidity({
   const handleSelectCurrencyA = useCallback(
     (currency: Currency) => {
       if (currencyIdB && currencyId(currency) === currencyIdB) {
-        history.push(`/remove/${currencyId(currency)}/${currencyIdA}`)
+        history.push(`/pools/remove/${currencyId(currency)}/${currencyIdA}`)
       } else {
-        history.push(`/remove/${currencyId(currency)}/${currencyIdB}`)
+        history.push(`/pools/remove/${currencyId(currency)}/${currencyIdB}`)
       }
     },
     [currencyIdA, currencyIdB, history]
@@ -462,9 +462,9 @@ export default function RemoveLiquidity({
   const handleSelectCurrencyB = useCallback(
     (currency: Currency) => {
       if (currencyIdA && currencyId(currency) === currencyIdA) {
-        history.push(`/remove/${currencyIdB}/${currencyId(currency)}`)
+        history.push(`/pools/remove/${currencyIdB}/${currencyId(currency)}`)
       } else {
-        history.push(`/remove/${currencyIdA}/${currencyId(currency)}`)
+        history.push(`/pools/remove/${currencyIdA}/${currencyId(currency)}`)
       }
     },
     [currencyIdA, currencyIdB, history]
@@ -596,7 +596,7 @@ export default function RemoveLiquidity({
                       <RowBetween style={{ justifyContent: 'flex-end' }}>
                         {oneCurrencyIsNative ? (
                           <StyledInternalLink
-                            to={`/remove/${
+                            to={`/pools/remove/${
                               currencyA === nativeCurrency ? nativeCurrencyWrapper?.address : currencyIdA
                             }/${currencyB === nativeCurrency ? nativeCurrencyWrapper?.address : currencyIdB}`}
                           >
@@ -612,7 +612,7 @@ export default function RemoveLiquidity({
                           </StyledInternalLink>
                         ) : oneCurrencyIsNativeWrapper ? (
                           <StyledInternalLink
-                            to={`/remove/${
+                            to={`/pools/remove/${
                               currencyA && nativeCurrencyWrapper && currencyEquals(currencyA, nativeCurrencyWrapper)
                                 ? nativeCurrency.symbol
                                 : currencyIdA

--- a/src/pages/RemoveLiquidity/redirects.tsx
+++ b/src/pages/RemoveLiquidity/redirects.tsx
@@ -13,5 +13,5 @@ export function RedirectOldRemoveLiquidityPathStructure({
   }
   const [currency0, currency1] = tokens.split('-')
 
-  return <Redirect to={`/remove/${currency0}/${currency1}`} />
+  return <Redirect to={`/pools/remove/${currency0}/${currency1}`} />
 }


### PR DESCRIPTION

### Summary

This PR fixes menu item **liquidity** not highlighting when `/add`, `/remove` or `/create` routes.
I've added  prefix `/pools` to those routes, because it all pools related.

**Before**
/add
<img width="1667" alt="image" src="https://user-images.githubusercontent.com/5664434/169042108-be609f21-2a7c-4e09-9cc5-d45631e5f464.png">

**Now**
/pools/add

<img width="1824" alt="image" src="https://user-images.githubusercontent.com/5664434/169042285-9b71fc8d-c09b-44e7-8d5a-74d1beb690a9.png">


  # To Test

1.  Open the page `liquidity`
- [ ] click on a pair
- [ ] click on "add liquidity"
- [ ] check highlighted "liquidity" on menu
2. Open the page `liquidity`
- [ ] click on "create pair"
- [ ] check highlighted "liquidity" on menu

