### PR TITLE
fix(ecoBridge): clear legacy txs interface to preserve compatibility

### DIFF
--- a/src/services/EcoBridge/EcoBridge.config.ts
+++ b/src/services/EcoBridge/EcoBridge.config.ts
@@ -41,7 +41,7 @@ export const fixCorruptedEcoBridgeLocalStorageEntries = (persistenceNamespace: s
     const entry = window.localStorage.getItem(fullKey)
 
     if (entry && !isEntityAdapter.test(entry)) {
-      console.warn(`${fullKey} uses legacy store interface. It was cleared to perserve compatibility.`)
+      console.warn(`${fullKey} uses legacy store interface. It was cleared to preserve compatibility.`)
       window.localStorage.removeItem(fullKey)
     }
   })

--- a/src/services/EcoBridge/EcoBridge.config.ts
+++ b/src/services/EcoBridge/EcoBridge.config.ts
@@ -3,6 +3,7 @@ import { ChainId } from '@swapr/sdk'
 import { EcoBridgeChildBase } from './EcoBridge.utils'
 import { SocketBridge } from './Socket/SocketBridge'
 
+const socketBridgeId = 'socket'
 //supported chains are bidirectional
 export const ecoBridgeConfig: EcoBridgeChildBase[] = [
   new ArbitrumBridge({
@@ -29,3 +30,19 @@ export const ecoBridgeConfig: EcoBridgeChildBase[] = [
 export const ecoBridgePersistedKeys = ecoBridgeConfig.map(
   bridgeConfig => `ecoBridge.${bridgeConfig.bridgeId}.transactions`
 )
+
+export const fixCorruptedEcoBridgeLocalStorageEntries = (persistenceNamespace: string) => {
+  const isEntityAdapter = /^{"ids":\[/g
+
+  const keysWithoutSocket = ecoBridgePersistedKeys.filter(key => !key.includes(socketBridgeId))
+
+  keysWithoutSocket.forEach(key => {
+    const fullKey = `${persistenceNamespace}_${key}`
+    const entry = window.localStorage.getItem(fullKey)
+
+    if (entry && !isEntityAdapter.test(entry)) {
+      console.warn(`${fullKey} uses legacy store interface. It was cleared to perserve compatibility.`)
+      window.localStorage.removeItem(fullKey)
+    }
+  })
+}

--- a/src/state/index.ts
+++ b/src/state/index.ts
@@ -14,11 +14,18 @@ import multiChainLinks from './multi-chain-links/reducer'
 import lists from './lists/reducer'
 import bridgeTransactions from './bridgeTransactions/reducer'
 import ecoBridge from '../services/EcoBridge/store/EcoBridge.reducer'
-import { ecoBridgePersistedKeys } from '../services/EcoBridge/EcoBridge.config'
+import {
+  ecoBridgePersistedKeys,
+  fixCorruptedEcoBridgeLocalStorageEntries,
+} from '../services/EcoBridge/EcoBridge.config'
 
 const PERSISTED_KEYS: string[] = ['user', 'transactions', 'claim', 'bridgeTransactions', ...ecoBridgePersistedKeys]
 
 const persistenceNamespace = 'swapr'
+
+// Fixes #1012
+fixCorruptedEcoBridgeLocalStorageEntries(persistenceNamespace)
+
 const store = configureStore({
   reducer: {
     application,


### PR DESCRIPTION
# Summary

Fixes #1012

During development interface of `arbitrumBridge` transactions has been changed few times to end up with `entityAdapter`. If user had interacted with interfaces used meanwhile they have been persisted in `localStorage` by `redux-localstorage-simple` lib. Due to how it works, it loaded persisted incompatible state from `localStorage` (ignoring new initial store interface). Redux then interacted with stale state throwing errors.

This fix basically checks for presence of persisted keys and checks if it's compatible with `entityAdapter`, if not - entry is cleared and `redux` recreates store with correct interface. It's lightweight and takes around 0.3 ms to execute regardless of transactions length.
 
# To Test
1. Recreate a bug with steps provided in #1012
2. In console you should see warning saying that entry was cleared to preserve backward compatibility (or something like that)
3. App should work as expected
