### PR TITLE
fix: fix decimals error when swapping

### DIFF
--- a/src/utils/prices.ts
+++ b/src/utils/prices.ts
@@ -192,14 +192,18 @@ export function getLpTokenPrice(
  * @param rounding Rounding mode
  */
 export const limitNumberOfDecimalPlaces = (
-  value?: Fraction,
+  value?: CurrencyAmount | Fraction,
   significantDigits = 6,
   format = { groupSeparator: '' },
   rounding = Decimal.ROUND_DOWN
 ): string | undefined => {
   if (!value || value.equalTo(ZERO)) return undefined
+  if (value instanceof CurrencyAmount && value.currency.decimals < significantDigits)
+    significantDigits = value.currency.decimals
+
   const fixedQuotient = value.toFixed(significantDigits)
   Decimal.set({ precision: significantDigits + 1, rounding })
   const quotient = new Decimal(fixedQuotient).toSignificantDigits(6)
+
   return quotient.toFormat(quotient.decimalPlaces(), format)
 }


### PR DESCRIPTION
# Summary

Fixes #918

Fix DECIMALS error showing up when trading ZEENUS, as this currency has 0 decimals.

<img width="592" alt="image" src="https://user-images.githubusercontent.com/23079677/170248853-97b575f2-6bbb-467e-8fde-c4d326dc2653.png">

  # To Test

1. Open the page `swap`
2. Choose ZEENUS for swapping
- [ ] Verify app doesn't crash anymore
