### PR TITLE
bugfix: Eco Router returns no results on Polygon 

### DIFF
--- a/src/lib/eco-router/api.ts
+++ b/src/lib/eco-router/api.ts
@@ -68,6 +68,7 @@ export async function getExactIn(
         currencyA: currencyAmountIn.currency,
         currencyB: currencyOut,
         platform,
+        provider,
       })
       return (
         UniswapV2Trade.computeTradesExactIn({
@@ -152,6 +153,7 @@ export async function getExactOut(
         currencyA: currencyAmountOut.currency,
         currencyB: currencyIn,
         platform,
+        provider,
       })
       return (
         UniswapV2Trade.computeTradesExactOut({

--- a/src/lib/eco-router/platforms.ts
+++ b/src/lib/eco-router/platforms.ts
@@ -11,5 +11,7 @@ export function getUniswapV2PlatformList(chainId: ChainId): UniswapV2RoutablePla
     UniswapV2RoutablePlatform.HONEYSWAP,
     UniswapV2RoutablePlatform.BAOSWAP,
     UniswapV2RoutablePlatform.LEVINSWAP,
-  ].filter(platform => platform.supportsChain(chainId as ChainId))
+    UniswapV2RoutablePlatform.DFYN,
+    UniswapV2RoutablePlatform.QUICKSWAP,
+  ].filter(platform => platform.supportsChain(chainId))
 }


### PR DESCRIPTION
# Summary

Quick fix for Polygon network. :) 

# To Test

1. Open the dapp.
2. Select Polygon.
3. Select trading pairs and amounts
4. Eco Router should show either DYFN, Sushi, or QuickSwap.

# Background

The SDK is missing the default fallback RPC provider entry for Polygon. If no provider is passed, the `JsonRpcProvider` from ethers defaults to `localhost: 8545` of ganache.
