### PR TITLE
fix: ReferenceError: Cannot access 'x' before initialization

### DIFF
--- a/src/components/SearchModal/CurrencySearchModal/CurrencySearchModal.component.tsx
+++ b/src/components/SearchModal/CurrencySearchModal/CurrencySearchModal.component.tsx
@@ -12,7 +12,7 @@ import { Manage } from '../Manage'
 import { CurrencySearchModalContext } from './CurrencySearchModal.context'
 import { CurrencyModalView, CurrencySearchModalProps } from './CurrencySearchModal.types'
 
-export const CurrencySearchModalComponent = ({
+export function CurrencySearchModalComponent({
   isOpen,
   onDismiss,
   onCurrencySelect: onCurrencySelectWithoutDismiss,
@@ -20,7 +20,7 @@ export const CurrencySearchModalComponent = ({
   otherSelectedCurrency,
   showCommonBases = false,
   showNativeCurrency = true,
-}: CurrencySearchModalProps) => {
+}: CurrencySearchModalProps) {
   const lastOpen = useLast(isOpen)
   const { modalView, setModalView, importList, listURL, importToken } = useContext(CurrencySearchModalContext)
 

--- a/src/components/SearchModal/CurrencySearchModal/CurrencySearchModal.container.tsx
+++ b/src/components/SearchModal/CurrencySearchModal/CurrencySearchModal.container.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { PropsWithChildren } from 'react'
 
 import { CurrencySearchContext } from '../CurrencySearch/CurrencySearch.context'
 import { ListRowContext, ManageListsContext } from '../ManageLists/ManageLists.context'
@@ -7,13 +7,13 @@ import { CurrencySearchModalContext } from './CurrencySearchModal.context'
 import { useCurrencySearchModalSwap } from './CurrencySearchModal.hooks'
 import { CurrencySearchModalProps, CurrencySearchModalProviderProps } from './CurrencySearchModal.types'
 
-export const CurrencySearchModalProvider: React.FC<CurrencySearchModalProviderProps> = ({
+export function CurrencySearchModalProvider({
   children,
   listRowContext,
   manageListsContext,
   currencySearchContext,
   currencySearchModalContext,
-}) => {
+}: PropsWithChildren<CurrencySearchModalProviderProps>) {
   return (
     <CurrencySearchModalContext.Provider value={currencySearchModalContext}>
       <CurrencySearchContext.Provider value={currencySearchContext}>
@@ -25,7 +25,7 @@ export const CurrencySearchModalProvider: React.FC<CurrencySearchModalProviderPr
   )
 }
 
-export const CurrencySearchModal = (props: CurrencySearchModalProps) => {
+export function CurrencySearchModal(props: CurrencySearchModalProps) {
   const {
     listRowContext,
     manageListsContext,


### PR DESCRIPTION
# Summary

Fixes this weird error that appeared after #1056 when running `yarn start`

<img width="862" alt="image" src="https://user-images.githubusercontent.com/1926216/172961038-fab1ebf1-a4bd-4a3a-8675-73b30c6d1e40.png">



