### PR TITLE
feature: update Swapr SDK to v1.4 beta

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@reduxjs/toolkit": "^1.6.1",
     "@swapr/core": "^0.3.18",
     "@swapr/periphery": "^0.3.20",
-    "@swapr/sdk": "^1.4.0-beta.2",
+    "@swapr/sdk": "^1.4.2-beta.0",
     "@uniswap/token-lists": "^1.0.0-beta.27",
     "@web3-react/core": "^6.1.9",
     "@web3-react/injected-connector": "^6.0.7",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@reduxjs/toolkit": "^1.6.1",
     "@swapr/core": "^0.3.18",
     "@swapr/periphery": "^0.3.20",
-    "@swapr/sdk": "1.3.0-beta.2",
+    "@swapr/sdk": "^1.4.0-beta.2",
     "@uniswap/token-lists": "^1.0.0-beta.27",
     "@web3-react/core": "^6.1.9",
     "@web3-react/injected-connector": "^6.0.7",

--- a/src/lib/eco-router/api.ts
+++ b/src/lib/eco-router/api.ts
@@ -1,8 +1,16 @@
 import { AddressZero } from '@ethersproject/constants'
 import { Provider } from '@ethersproject/providers'
-import { CurveTrade, RoutablePlatform, Token, Trade, TradeType, UniswapTrade, UniswapV2Trade } from '@swapr/sdk'
+import {
+  CurveTrade,
+  getAllCommonUniswapV2Pairs,
+  RoutablePlatform,
+  Token,
+  Trade,
+  TradeType,
+  UniswapTrade,
+  UniswapV2Trade,
+} from '@swapr/sdk'
 // Low-level API for Uniswap V2
-import { getAllCommonPairs } from '@swapr/sdk/dist/entities/trades/uniswap-v2/contracts'
 
 import { getUniswapV2PlatformList } from './platforms'
 // Types
@@ -64,7 +72,7 @@ export async function getExactIn(
 
   const uniswapV2TradesList = uniswapV2PlatformList.map(async platform => {
     try {
-      const pairs = await getAllCommonPairs({
+      const pairs = await getAllCommonUniswapV2Pairs({
         currencyA: currencyAmountIn.currency,
         currencyB: currencyOut,
         platform,
@@ -173,7 +181,7 @@ export async function getExactOut(
 
   const uniswapV2TradesList = uniswapV2PlatformList.map(async platform => {
     try {
-      const pairs = await getAllCommonPairs({
+      const pairs = await getAllCommonUniswapV2Pairs({
         currencyA: currencyAmountOut.currency,
         currencyB: currencyIn,
         platform,

--- a/src/lib/eco-router/api.ts
+++ b/src/lib/eco-router/api.ts
@@ -246,35 +246,9 @@ export async function getExactOut(
       })
   })
 
-  // Curve
-  const curveTrade = new Promise<CurveTrade | undefined>(async resolve => {
-    if (!RoutablePlatform.CURVE.supportsChain(chainId)) {
-      return resolve(undefined)
-    }
-
-    CurveTrade.bestTradeExactOut(
-      {
-        currencyAmountOut,
-        currencyIn,
-        maximumSlippage,
-        receiver,
-      },
-      provider
-    )
-      .then(resolve)
-      .catch(error => {
-        errors.push(error)
-        resolve(undefined)
-      })
-  })
-
   // Wait for all promises to resolve, and
   // remove undefined values
-  const unsortedTradesWithUndefined = await Promise.all<Trade | undefined>([
-    ...uniswapV2TradesList,
-    curveTrade,
-    uniswapTrade,
-  ])
+  const unsortedTradesWithUndefined = await Promise.all<Trade | undefined>([...uniswapV2TradesList, uniswapTrade])
   const unsortedTrades = unsortedTradesWithUndefined.filter((trade): trade is Trade => !!trade)
 
   // Return the list of sorted trades

--- a/src/lib/eco-router/api.ts
+++ b/src/lib/eco-router/api.ts
@@ -3,6 +3,8 @@ import { Provider } from '@ethersproject/providers'
 import {
   CurveTrade,
   getAllCommonUniswapV2Pairs,
+  getAllCommonUniswapV2PairsFromSubgraph,
+  Pair,
   RoutablePlatform,
   Token,
   Trade,
@@ -72,12 +74,21 @@ export async function getExactIn(
 
   const uniswapV2TradesList = uniswapV2PlatformList.map(async platform => {
     try {
-      const pairs = await getAllCommonUniswapV2Pairs({
+      let pairs: Pair[] = []
+
+      const getAllCommonUniswapV2PairsParams = {
         currencyA: currencyAmountIn.currency,
         currencyB: currencyOut,
         platform,
         provider,
-      })
+      }
+
+      if (platform.subgraphEndpoint[chainId] !== undefined) {
+        pairs = await getAllCommonUniswapV2PairsFromSubgraph(getAllCommonUniswapV2PairsParams)
+      } else {
+        pairs = await getAllCommonUniswapV2Pairs(getAllCommonUniswapV2PairsParams)
+      }
+
       return (
         UniswapV2Trade.computeTradesExactIn({
           currencyAmountIn,
@@ -181,12 +192,21 @@ export async function getExactOut(
 
   const uniswapV2TradesList = uniswapV2PlatformList.map(async platform => {
     try {
-      const pairs = await getAllCommonUniswapV2Pairs({
+      let pairs: Pair[] = []
+
+      const getAllCommonUniswapV2PairsParams = {
         currencyA: currencyAmountOut.currency,
         currencyB: currencyIn,
         platform,
         provider,
-      })
+      }
+
+      if (platform.subgraphEndpoint[chainId] !== undefined) {
+        pairs = await getAllCommonUniswapV2PairsFromSubgraph(getAllCommonUniswapV2PairsParams)
+      } else {
+        pairs = await getAllCommonUniswapV2Pairs(getAllCommonUniswapV2PairsParams)
+      }
+
       return (
         UniswapV2Trade.computeTradesExactOut({
           currencyAmountOut,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2881,10 +2881,10 @@
   dependencies:
     "@swapr/core" "^0.3.17"
 
-"@swapr/sdk@1.3.0-beta.2":
-  version "1.3.0-beta.2"
-  resolved "https://registry.yarnpkg.com/@swapr/sdk/-/sdk-1.3.0-beta.2.tgz#dc810919e230d3983a5f523f527cb0294e0f7c8e"
-  integrity sha512-fW3wnzQiIdrBZHse3/U0l1436tB9IJhYzH/U6IdGVIHvjv8Nq0XdaepMMy32jLH7VYmhsYzDvjU9d0ALUORF5g==
+"@swapr/sdk@^1.4.0-beta.2":
+  version "1.4.0-beta.2"
+  resolved "https://registry.yarnpkg.com/@swapr/sdk/-/sdk-1.4.0-beta.2.tgz#6ae63084824cdd584d6cce9c4b29760fa9962e54"
+  integrity sha512-cVDEtdNVECV0GaZMEfg8u2F8ax83g3Y35ZH++nphhlkgQYf14cM6gDNgy1VPi0sv0I06nFuN8K0VjBD6fHNfUw==
   dependencies:
     "@ethersproject/abi" "^5.4.0"
     "@ethersproject/address" "^5.4.0"
@@ -2904,6 +2904,7 @@
     dayjs "^1.11.0"
     debug "^4.3.4"
     decimal.js-light "^2.5.1"
+    graphql-request "^4.3.0"
     jsbi "^3.1.1"
     lodash.flatmap "^4.5.0"
     node-fetch "2"
@@ -7585,7 +7586,7 @@ cross-env@^7.0.2:
   dependencies:
     cross-spawn "^7.0.1"
 
-cross-fetch@3.1.5, cross-fetch@^3.0.6, cross-fetch@^3.1.4:
+cross-fetch@3.1.5, cross-fetch@^3.0.6, cross-fetch@^3.1.4, cross-fetch@^3.1.5:
   version "3.1.5"
   resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.5.tgz#e1389f44d9e7ba767907f7af8454787952ab534f"
   integrity sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==
@@ -11068,6 +11069,15 @@ graphql-request@^3.4.0, graphql-request@^3.6.0:
   integrity sha512-dw5PxHCgBneN2DDNqpWu8QkbbJ07oOziy8z+bK/TAXufsOLaETuVO4GkXrbs0WjhdKhBMN3BkpN/RIvUHkmNUQ==
   dependencies:
     cross-fetch "^3.0.6"
+    extract-files "^9.0.0"
+    form-data "^3.0.0"
+
+graphql-request@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/graphql-request/-/graphql-request-4.3.0.tgz#b934e08fcae764aa2cdc697d3c821f046cb5dbf2"
+  integrity sha512-2v6hQViJvSsifK606AliqiNiijb1uwWp6Re7o0RTyH+uRTv/u7Uqm2g4Fjq/LgZIzARB38RZEvVBFOQOVdlBow==
+  dependencies:
+    cross-fetch "^3.1.5"
     extract-files "^9.0.0"
     form-data "^3.0.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2881,10 +2881,10 @@
   dependencies:
     "@swapr/core" "^0.3.17"
 
-"@swapr/sdk@^1.4.0-beta.2":
-  version "1.4.0-beta.2"
-  resolved "https://registry.yarnpkg.com/@swapr/sdk/-/sdk-1.4.0-beta.2.tgz#6ae63084824cdd584d6cce9c4b29760fa9962e54"
-  integrity sha512-cVDEtdNVECV0GaZMEfg8u2F8ax83g3Y35ZH++nphhlkgQYf14cM6gDNgy1VPi0sv0I06nFuN8K0VjBD6fHNfUw==
+"@swapr/sdk@^1.4.2-beta.0":
+  version "1.4.2-beta.0"
+  resolved "https://registry.yarnpkg.com/@swapr/sdk/-/sdk-1.4.2-beta.0.tgz#6f5d41347eb61767c775e4d22dbd18a58faf6868"
+  integrity sha512-bR+eE7fVjArW4D6lX9lPID3Atgd5eJOI3/xDkBQrt4039qV730CHLt8s/mJjICq5XLBNZbHmcKzCcxerXiHOsQ==
   dependencies:
     "@ethersproject/abi" "^5.4.0"
     "@ethersproject/address" "^5.4.0"


### PR DESCRIPTION
# Summary

Updates Swapr SDK to v1.4 to use updated `getAllCommonUniswapV2Pairs` (less RPC calls using multicall2 for `getReserves` and `swapFee` on Swapr pairs) and `getAllCommonUniswapV2PairsFromSubgraph` which fetches the common pairs from the subgraph. This provides a better route efficiency by including all available pairs. 

This PR also fixes the execution price display bug found by @0xVenky. 


