### PR TITLE
make full text search on native currency name & symbol

### DIFF
--- a/src/components/SearchModal/CurrencySearch/CurrencySearch.component.tsx
+++ b/src/components/SearchModal/CurrencySearch/CurrencySearch.component.tsx
@@ -165,7 +165,7 @@ export const CurrencySearch = ({
         )}
       </AutoColumn>
       <Separator />
-      {filteredSortedTokens?.length > 0 || filteredInactiveTokensWithFallback.length > 0 ? (
+      {filteredSortedTokensWithNativeCurrency?.length > 0 || filteredInactiveTokensWithFallback.length > 0 ? (
         <CurrencyList
           currencies={filteredSortedTokensWithNativeCurrency}
           otherListTokens={filteredInactiveTokensWithFallback}

--- a/src/components/SearchModal/CurrencySearch/CurrencySearch.component.tsx
+++ b/src/components/SearchModal/CurrencySearch/CurrencySearch.component.tsx
@@ -74,8 +74,11 @@ export const CurrencySearch = ({
   const filteredSortedTokensWithNativeCurrency: Currency[] = useMemo(() => {
     if (!showNativeCurrency || !nativeCurrency.symbol || !nativeCurrency.name) return filteredSortedTokens
 
-    if (new RegExp(debouncedQuery.replace(/\s/g, ''), 'gi').test(`${nativeCurrency.symbol} ${nativeCurrency.name}`)) {
-      return nativeCurrency ? [nativeCurrency, ...filteredSortedTokens] : filteredSortedTokens
+    if (
+      nativeCurrency &&
+      new RegExp(debouncedQuery.replace(/\s/g, ''), 'gi').test(`${nativeCurrency.symbol} ${nativeCurrency.name}`)
+    ) {
+      return [nativeCurrency, ...filteredSortedTokens]
     }
 
     return filteredSortedTokens

--- a/src/components/SearchModal/CurrencySearch/CurrencySearch.component.tsx
+++ b/src/components/SearchModal/CurrencySearch/CurrencySearch.component.tsx
@@ -72,11 +72,12 @@ export const CurrencySearch = ({
   const filteredSortedTokens = useSortedTokensByQuery(sortedTokens, debouncedQuery)
 
   const filteredSortedTokensWithNativeCurrency: Currency[] = useMemo(() => {
-    if (!showNativeCurrency) return filteredSortedTokens
-    const s = debouncedQuery.toLowerCase().trim()
-    if (nativeCurrency.symbol && nativeCurrency.symbol.toLowerCase().startsWith(s)) {
+    if (!showNativeCurrency || !nativeCurrency.symbol || !nativeCurrency.name) return filteredSortedTokens
+
+    if (new RegExp(debouncedQuery.replace(/\s/g, ''), 'gi').test(`${nativeCurrency.symbol} ${nativeCurrency.name}`)) {
       return nativeCurrency ? [nativeCurrency, ...filteredSortedTokens] : filteredSortedTokens
     }
+
     return filteredSortedTokens
   }, [showNativeCurrency, filteredSortedTokens, debouncedQuery, nativeCurrency])
 


### PR DESCRIPTION
# Summary

Closes #951 

Native currency is now included in search results on similar rules as regular token (not only when query is beginning of native currency symbol).

To test:
1. Open token search in any place (swap/bridge) on any chain (examples are on mainnet as symbol is different than name (ETH, Ether)
2. Following queries should include ETH on token list (should work even when query starts with spaces):
- eth
- er
- the
- ...etc