### PR TITLE
bugfix: TypeError: Cannot read properties of undefined (reading 'stablecoin')

### DIFF
--- a/src/hooks/useUSDValue.ts
+++ b/src/hooks/useUSDValue.ts
@@ -34,9 +34,14 @@ const FETCH_PRICE_INTERVAL = 15000
 
 export function useUSDPrice(currencyAmount?: CurrencyAmount) {
   const { chainId } = useActiveWeb3React()
-  const { stablecoin, platform } = chainId
-    ? STABLECOIN_AND_PLATFOM_BY_CHAIN[chainId]
-    : { stablecoin: undefined, platform: undefined }
+
+  let stablecoin: Token | undefined = undefined
+  let platform: UniswapV2RoutablePlatform | undefined = undefined
+
+  if (chainId && STABLECOIN_AND_PLATFOM_BY_CHAIN[chainId] !== undefined) {
+    stablecoin = STABLECOIN_AND_PLATFOM_BY_CHAIN[chainId].stablecoin
+    platform = STABLECOIN_AND_PLATFOM_BY_CHAIN[chainId].platform
+  }
 
   const tradeExactInUniswapV2 = useTradeExactInUniswapV2(currencyAmount, stablecoin, platform)
 


### PR DESCRIPTION
# Summary

Starts with undefined values for `stablecoin` and `platform` and then assign them if they're available in `STABLECOIN_AND_PLATFOM_BY_CHAIN`

  # To Test

1. Go to Swapr 
2. Connect wallet
3. Switch to Rinkeby or Arbitrum Rinkeby
4. Swapbox should operate as expected, just without showing USD values