### PR TITLE
Upgrade tsc version

### DIFF
--- a/package.json
+++ b/package.json
@@ -162,6 +162,6 @@
     "react-error-overlay": "6.0.9",
     "react-scripts": "4.0.3",
     "serve": "^11.3.2",
-    "typescript": "^3.8.3"
+    "typescript": "^4.7.3"
   }
 }

--- a/src/components/SearchModal/utils/filtering.ts
+++ b/src/components/SearchModal/utils/filtering.ts
@@ -1,4 +1,4 @@
-import { Pair, Token } from '@swapr/sdk'
+import { Currency, Pair, Token } from '@swapr/sdk'
 
 import { TokenInfo } from '@uniswap/token-lists'
 import { useMemo } from 'react'
@@ -12,7 +12,7 @@ export function createTokenFilterFunction<T extends Token | TokenInfo>(search: s
 
   if (searchingAddress) {
     const lower = searchingAddress.toLowerCase()
-    return (t: T) => ('isToken' in t ? searchingAddress === t.address : lower === t.address.toLowerCase())
+    return (t: T | Currency) => 'address' in t && lower === t.address?.toLowerCase()
   }
 
   const lowerSearchParts = search

--- a/src/state/multicall/updater.tsx
+++ b/src/state/multicall/updater.tsx
@@ -19,6 +19,15 @@ import { Call, parseCallKey } from './utils'
  * @param chunk chunk of calls to make
  * @param blockNumber block number passed as the block tag in the eth_call
  */
+type ErrorWithMessageAndCode = {
+  code: number
+  message: string
+}
+
+function isErrorWithMessageAndCode(error: unknown): error is ErrorWithMessageAndCode {
+  return (typeof error === 'object' && error && ('message' in error || 'code' in error)) ?? false
+}
+
 async function fetchChunk(multicall: Contract, chunk: Call[], blockNumber: number): Promise<string[]> {
   try {
     const { returnData } = await multicall.callStatic.aggregate(
@@ -30,8 +39,10 @@ async function fetchChunk(multicall: Contract, chunk: Call[], blockNumber: numbe
     )
     return returnData
   } catch (error) {
-    if (error.code === -32000 || error.message?.indexOf('header not found') !== -1) {
-      throw new RetryableError(`header not found for block number ${blockNumber}`)
+    if (isErrorWithMessageAndCode(error)) {
+      if (error.code === -32000 || error.message?.indexOf('header not found') !== -1) {
+        throw new RetryableError(`header not found for block number ${blockNumber}`)
+      }
     }
     console.error('Failed to fetch chunk', error)
     throw error

--- a/src/utils/retry.ts
+++ b/src/utils/retry.ts
@@ -66,7 +66,8 @@ export function retry<T>(
         if (completed) {
           break
         }
-        if (n <= 0 || (isRetryableError(error) && !error.isRetryableError)) {
+
+        if (n <= 0 || !isRetryableError(error) || !error.isRetryableError) {
           reject(error)
           completed = true
           break

--- a/src/utils/retry.ts
+++ b/src/utils/retry.ts
@@ -36,6 +36,15 @@ export interface RetryOptions {
  * @param minWait min wait between retries in ms
  * @param maxWait max wait between retries in ms
  */
+
+type ErrorWithRetryable = {
+  isRetryableError: boolean
+}
+
+function isRetryableError(error: unknown): error is ErrorWithRetryable {
+  return (typeof error === 'object' && error && 'isRetryableError' in error) ?? false
+}
+
 export function retry<T>(
   fn: () => Promise<T>,
   { n, minWait, maxWait }: RetryOptions
@@ -57,7 +66,7 @@ export function retry<T>(
         if (completed) {
           break
         }
-        if (n <= 0 || !error.isRetryableError) {
+        if (n <= 0 || (isRetryableError(error) && !error.isRetryableError)) {
           reject(error)
           completed = true
           break

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,7 +22,7 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "react-jsx",
+    "jsx": "react",
     "downlevelIteration": true,
     "allowSyntheticDefaultImports": true,
     "types": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "ES2018",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
@@ -18,11 +22,21 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "react",
+    "jsx": "react-jsx",
     "downlevelIteration": true,
     "allowSyntheticDefaultImports": true,
-    "types": ["jest"]
+    "types": [
+      "jest"
+    ]
   },
-  "exclude": ["node_modules", "cypress", "./src/services/EcoBridge/Socket/api/generated"],
-  "include": ["./src/**/*.ts", "./src/**/*.tsx", "src/components/Confetti/index.js"]
+  "exclude": [
+    "node_modules",
+    "cypress",
+    "./src/services/EcoBridge/Socket/api/generated"
+  ],
+  "include": [
+    "./src/**/*.ts",
+    "./src/**/*.tsx",
+    "src/components/Confetti/index.js"
+  ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -19746,10 +19746,15 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.8.3, typescript@^3.9.5:
+typescript@^3.9.5:
   version "3.9.10"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.10.tgz#70f3910ac7a51ed6bef79da7800690b19bf778b8"
   integrity sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==
+
+typescript@^4.7.3:
+  version "4.7.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.3.tgz#8364b502d5257b540f9de4c40be84c98e23a129d"
+  integrity sha512-WOkT3XYvrpXx4vMMqlD+8R8R37fZkjyLGlxavMc4iB8lrl8L0DeTcHbYgw/v0N/z9wAFsgBhcsF0ruoySS22mA==
 
 u2f-api@0.2.7:
   version "0.2.7"


### PR DESCRIPTION
# Summary

### Upgraded `typescript` version.

#### This pull request is required by `Connext Bridge` pr.

Currently `typecheck` fails on `Connext Bridge` because the version of typescript is too low (`from: ^3.8.3` to: `^4.7.3`)
![image](https://user-images.githubusercontent.com/46563377/173627642-4875ce3f-aa43-45e4-a896-0d09bae14e48.png)
 
#### This piece of code is copied from `Uniswap`
```ts
if (searchingAddress) {
    const lower = searchingAddress.toLowerCase()
    return (t: T | Currency) => 'address' in t && lower === t.address?.toLowerCase()
}
```

