### PR TITLE
Fix: show 'install MetaMask' option if Coinbase already installed

### DIFF
--- a/src/components/Web3Status/ConnectWalletPopover.tsx
+++ b/src/components/Web3Status/ConnectWalletPopover.tsx
@@ -142,7 +142,7 @@ export const ConnectWalletPopover = ({ setModal, tryActivation, children }: Conn
       // overwrite injected when needed
       if (option.connector === injected) {
         // don't show injected if there's no injected provider
-        if (!(window.web3 || window.ethereum)) {
+        if (!(window.web3 || window.ethereum) || ((window.web3 || window.ethereum) && !isMetamask)) {
           if (option.name === 'MetaMask') {
             return (
               <Item


### PR DESCRIPTION
# Summary

Fixes #1092 

Fixes the problem described in issue. When connecting Coinbase instead of option to eg "install metamask" there is Injected option - which can be used to connect Coinbase Wallet but then switching network from dapp does not work.


  # To Test

- [ ] Uninstall or disable MetaMask extension
- [ ] Install only Coinbase Wallet
- [ ] Click on "Connect Wallet" button 
- [ ] Coinbase wallet can be connected and works as expected
- [ ] For MetaMask it is shown "Install Metamask" option and after clicking the download page is open. 
- [ ] After installing all wallets work as expected


  # Additional info

Injected wallet issue will be handled by #817, so this is just temporary fix. 

