### PR TITLE
Fix for precommit lint check for tests files

### DIFF
--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -1,4 +1,4 @@
 {
-  "**/*.{cjs,mjs,js,jsx,ts,tsx}": "eslint --fix",
+  "**/!(*Tests).{cjs,mjs,js,jsx,ts,tsx}": "eslint --fix",
   "**/*.{cjs,mjs,js,jsx,ts,tsx,css,json}": "prettier --write"
 }


### PR DESCRIPTION
There is no need for running precommit lint check for tests files - it fail as in some of those files there are hard coded awaits which are impossible to avoid due to Synpress bug