### PR TITLE
fix: connect-coinbase-wallet

### DIFF
--- a/src/connectors/CustomWalletLinkConnector.ts
+++ b/src/connectors/CustomWalletLinkConnector.ts
@@ -38,7 +38,10 @@ export class CustomWalletLinkConnector extends AbstractConnector {
   }
 
   public async activate(): Promise<ConnectorUpdate> {
-    if (window.ethereum && window.ethereum.isCoinbaseWallet === true) {
+    // temporary fix to set provider
+    // todo: upgrade web3-react & set provider only if it is CoinbaseWallet
+    // if (window.ethereum && window.ethereum.isCoinbaseWallet === true) {
+    if (window.ethereum) {
       // user is in the dapp browser on Coinbase Wallet
       this.provider = window.ethereum
     } else if (!this.walletLink) {


### PR DESCRIPTION
# Summary

Fixes #1133 

If MetaMask and Coinbase wallet are both installed and enabled an error occurs during Coinbase connecting. It is not possible to use this one. 
This is just a quick fix for the problem, more complex one will be implemented with #817.

![image](https://user-images.githubusercontent.com/88723742/175549759-4cb4a7ac-0c28-4e13-ae21-932fc85193bd.png)

  # To Test

Open Swapr app:
- [ ] Check if MetaMask can be connected 
- [ ] Check if Coinbase can be connected
- [ ] Both wallets can be used as expected (swith network, approve transaction etc)

