### PR TITLE
Auto rebase dependabot PR's

### DIFF
--- a/.github/workflows/auto-rebase-dependabot.yml
+++ b/.github/workflows/auto-rebase-dependabot.yml
@@ -1,0 +1,21 @@
+name: Auto-rebase dependabot PRs
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  rebase-dependabot:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: 'Auto-rebase'
+        uses: actions/github-script@v6
+        with:
+          script: |
+            await github.rest.issues.createComment({ 
+              issue_number: context.issue.number, 
+              owner: context.repo.owner, 
+              repo: context.repo.repo, 
+              body: '@dependabot rebase',
+            });


### PR DESCRIPTION
# Summary
Dependabot PR's base may not be updated to the latest and can create conflicts. So creating a CI workflow to auto rebase it once dependabot creates a PR.

  # To Test

Once dependabot creates a new PR it will be rebased to the latest 


