### PR TITLE
disable native currency when trying bridge from testnet to realnet

### DIFF
--- a/src/components/SearchModal/CurrencySearch/CurrencySearch.component.tsx
+++ b/src/components/SearchModal/CurrencySearch/CurrencySearch.component.tsx
@@ -165,7 +165,7 @@ export const CurrencySearch = ({
         )}
       </AutoColumn>
       <Separator />
-      {filteredSortedTokensWithNativeCurrency?.length > 0 || filteredInactiveTokensWithFallback.length > 0 ? (
+      {filteredSortedTokens?.length > 0 || filteredInactiveTokensWithFallback.length > 0 ? (
         <CurrencyList
           currencies={filteredSortedTokensWithNativeCurrency}
           otherListTokens={filteredInactiveTokensWithFallback}


### PR DESCRIPTION
# Summary
Fix #1134
Previously user could select native currency when trying bridge from `testnet` to `realnet`
![image](https://user-images.githubusercontent.com/46563377/175970966-523ac715-5062-4098-9163-7c33e7f02635.png)

# To Test
1. Go to page `Bridge`
2. Set `fromChain` to 'Rinkeby' or `A. Rinkeby`
3. Set `toChain` to realnet (eg `Ethereum`, `Gnosis`)
4. Open token list
5. There shouldn't be any token

