### PR TITLE
Removed unwanted type package and .vscode printWidth fix

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,7 +9,6 @@
     "source.fixAll.eslint": true
   },
   "typescript.preferences.quoteStyle": "single",
-  "editor.rulers": [80],
   "editor.tabSize": 2,
   "files.associations": {
     "*.env.*": "env"

--- a/package.json
+++ b/package.json
@@ -110,7 +110,6 @@
     "@types/luxon": "^2.3.2",
     "@types/multicodec": "^1.0.0",
     "@types/node": "^18.0.0",
-    "@types/qs": "^6.9.7",
     "@types/react": "^16.9.34",
     "@types/react-datepicker": "^3.1.8",
     "@types/react-dom": "^16.9.7",


### PR DESCRIPTION
# Summary

Removed line in vscode to show printWidth
Removed unwanted @types/qs dependency since we are no longer using qs library


