### PR TITLE
fix: show is loading state when wallet is disconnected

### DIFF
--- a/src/components/swap/SwapButtons/SwapButton.tsx
+++ b/src/components/swap/SwapButtons/SwapButton.tsx
@@ -9,6 +9,7 @@ import {
   PRICE_IMPACT_MEDIUM,
   ROUTABLE_PLATFORM_STYLE,
   RoutablePlatformKeysByNetwork,
+  SWAP_INPUT_ERRORS,
 } from '../../../constants'
 import { useActiveWeb3React } from '../../../hooks'
 import { ButtonPrimary } from '../../Button/index'
@@ -48,9 +49,10 @@ const StyledPlataformText = styled(Text)`
 
 interface SwapButtonProps {
   platformName?: string
-  swapInputError?: string
+  swapInputError?: number
   priceImpactSeverity: number
   isExpertMode: boolean
+  amountInCurrencySymbol?: string
 }
 
 export const SwapButton = ({
@@ -58,15 +60,25 @@ export const SwapButton = ({
   swapInputError,
   priceImpactSeverity,
   isExpertMode,
+  amountInCurrencySymbol,
   ...rest
 }: SwapButtonProps & ButtonProps) => {
   const { t } = useTranslation()
+
+  const SWAP_INPUT_ERRORS_MESSAGE = {
+    [SWAP_INPUT_ERRORS.CONNECT_WALLET]: 'Connect wallet',
+    [SWAP_INPUT_ERRORS.ENTER_AMOUNT]: 'Enter amount',
+    [SWAP_INPUT_ERRORS.SELECT_TOKEN]: 'Select token',
+    [SWAP_INPUT_ERRORS.ENTER_RECIPIENT]: 'Enter recipient',
+    [SWAP_INPUT_ERRORS.INVALID_RECIPIENT]: 'Invalid recipient',
+    [SWAP_INPUT_ERRORS.INSUFFICIENT_BALANCE]: `Insufficient ${amountInCurrencySymbol} balance`,
+  }
 
   return (
     <StyledSwapButton gradientColor={platformName && ROUTABLE_PLATFORM_STYLE[platformName].gradientColor} {...rest}>
       <StyledSwapButtonText>
         {swapInputError ? (
-          swapInputError
+          SWAP_INPUT_ERRORS_MESSAGE[swapInputError]
         ) : priceImpactSeverity > PRICE_IMPACT_HIGH && !isExpertMode ? (
           t('priceImpactTooHigh')
         ) : (

--- a/src/components/swap/SwapButtons/SwapButtons.tsx
+++ b/src/components/swap/SwapButtons/SwapButtons.tsx
@@ -35,7 +35,7 @@ interface SwapButtonsProps {
   approvalSubmitted: boolean
   currencies: { [field in Field]?: Currency }
   trade: Trade | undefined
-  swapInputError: string | undefined
+  swapInputError: number | undefined
   swapErrorMessage: string | undefined
   loading: boolean
   handleSwap: () => void
@@ -203,6 +203,7 @@ export function SwapButtons({
       swapInputError={swapInputError}
       priceImpactSeverity={priceImpactSeverity}
       isExpertMode={isExpertMode}
-    ></SwapButton>
+      amountInCurrencySymbol={currencies[Field.INPUT]?.symbol}
+    />
   )
 }

--- a/src/constants/index.tsx
+++ b/src/constants/index.tsx
@@ -623,3 +623,12 @@ export const LIQUIDITY_SORTING_TYPES: { [key: string]: string } = {
   APY: 'APY',
   NEW: 'NEW',
 }
+
+export const SWAP_INPUT_ERRORS: Record<string, number> = {
+  CONNECT_WALLET: 1,
+  ENTER_AMOUNT: 2,
+  SELECT_TOKEN: 3,
+  ENTER_RECIPIENT: 4,
+  INVALID_RECIPIENT: 5,
+  INSUFFICIENT_BALANCE: 6,
+}


### PR DESCRIPTION
# Summary

Fixes #1188

Show is loading state when wallet is disconnected. Also improved how we handle swap input errors.

  # To Test

1. Open the page `swap`
2. Simulate a trade without connecting wallet
- [ ] Swapbox should start loading

