### PR TITLE
Fix typedValue when calling wrapCallback

### DIFF
--- a/src/pages/Swap/index.tsx
+++ b/src/pages/Swap/index.tsx
@@ -137,7 +137,7 @@ export default function Swap() {
     currencies.INPUT,
     currencies.OUTPUT,
     potentialTrade instanceof GnosisProtocolTrade,
-    potentialTrade?.inputAmount?.toSignificant(6)
+    potentialTrade?.inputAmount?.toSignificant(6) ?? typedValue
   )
 
   const bestPricedTrade = allPlatformTrades?.[0]


### PR DESCRIPTION
# Summary

No ticket.
Fixes a bug identified by Kacper when we try to wrap ETH on Rinkeby.

  # To Test

On the swap page
Using the Rinkeby Chain
Select ETH and WETH as input and output Currencies. Add a value
Verify WRAP is available and functional

  # Background

The origin of the problem was a change made when implementing the COW trade.
