### PR TITLE
fix: show balance on currency input

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -15,7 +15,7 @@
   "input": "Input",
   "output": "Output",
   "estimated": "estimated",
-  "balance": "Balance: {{ balanceInput }}",
+  "balance": "Balance: <0>{{ balanceInput }}</0>",
   "unlock": "Unlock",
   "pending": "Pending",
   "selectToken": "Select a token",

--- a/src/components/CurrencyInputPanel/CurrencyInputPanel.component.tsx
+++ b/src/components/CurrencyInputPanel/CurrencyInputPanel.component.tsx
@@ -18,7 +18,6 @@ import {
   Container,
   Content,
   CurrencySelect,
-  FiatRow,
   InputPanel,
   InputRow,
   LabelRow,
@@ -165,7 +164,7 @@ export const CurrencyInputPanelComponent = ({
               </Aligner>
             </CurrencySelect>
           </InputRow>
-          <FiatRow>
+          <div>
             <RowBetween>
               <FiatValueDetails fiatValue={fiatValue} priceImpact={priceImpact} isFallback={isFallbackFiatValue} />
               <CurrencyUserBalance
@@ -178,7 +177,7 @@ export const CurrencyInputPanelComponent = ({
                 onMax={handleOnMax}
               />
             </RowBetween>
-          </FiatRow>
+          </div>
         </Content>
       </Container>
       {!disableCurrencySelect && onCurrencySelect && (

--- a/src/components/CurrencyInputPanel/CurrencyInputPanel.styles.ts
+++ b/src/components/CurrencyInputPanel/CurrencyInputPanel.styles.ts
@@ -1,5 +1,7 @@
 import transparentize from 'polished/lib/color/transparentize'
+import { TextProps } from 'rebass'
 import styled from 'styled-components'
+import { TYPE } from 'theme'
 
 import { ReactComponent as DropDown } from '../../assets/images/dropdown.svg'
 import { breakpoints } from '../../utils/theme'
@@ -92,4 +94,6 @@ export const UppercaseHelper = styled.span`
   text-transform: uppercase;
 `
 
-export const FiatRow = styled.div``
+export const UnderlinedSmallText = styled(TYPE.darkGray)<TextProps>`
+  text-decoration: underline;
+`

--- a/src/components/CurrencyInputPanel/CurrencyUserBalance.tsx
+++ b/src/components/CurrencyInputPanel/CurrencyUserBalance.tsx
@@ -5,7 +5,7 @@ import { useTheme } from 'styled-components'
 import { useActiveWeb3React } from '../../hooks'
 import { TYPE } from '../../theme'
 import { limitNumberOfDecimalPlaces } from '../../utils/prices'
-import { UppercaseHelper } from './CurrencyInputPanel.styles'
+import { UnderlinedSmallText, UppercaseHelper } from './CurrencyInputPanel.styles'
 import { CurrencyUserBalanceProps } from './CurrencyInputPanel.types'
 
 export const CurrencyUserBalance = ({
@@ -20,48 +20,57 @@ export const CurrencyUserBalance = ({
   const { account } = useActiveWeb3React()
   const theme = useTheme()
 
-  if (account) {
-    return (
-      <TYPE.body
-        onClick={onMax}
-        fontWeight="600"
-        fontSize="10px"
-        lineHeight="13px"
-        letterSpacing="0.08em"
-        style={{
-          display: 'inline',
-          marginLeft: 'auto',
-          cursor: !hideBalance && !!(currency || pair) && (balance || selectedCurrencyBalance) ? 'pointer' : 'auto',
-        }}
-      >
-        <UppercaseHelper>
-          {!hideBalance && !!(currency || pair) && (balance || selectedCurrencyBalance) && (
-            <>
-              {customBalanceText ?? (
-                <Trans
-                  i18nKey="balance"
-                  values={{
-                    balanceInput: limitNumberOfDecimalPlaces(balance || selectedCurrencyBalance) || '0',
-                  }}
-                  components={[
-                    <span
-                      key="1"
-                      style={{
-                        fontSize: '11px',
-                        color: theme.text3,
-                        fontWeight: 600,
-                        textDecoration: 'underline',
-                      }}
-                    ></span>,
-                  ]}
-                />
-              )}
-            </>
-          )}
-        </UppercaseHelper>
-      </TYPE.body>
-    )
+  if (!account) {
+    return null
   }
 
-  return null
+  const trimmedBalance: string = limitNumberOfDecimalPlaces(balance || selectedCurrencyBalance) || '0'
+
+  return (
+    <TYPE.body
+      onClick={onMax}
+      fontWeight="600"
+      fontSize="10px"
+      lineHeight="13px"
+      letterSpacing="0.08em"
+      style={{
+        display: 'inline',
+        marginLeft: 'auto',
+        cursor: !hideBalance && !!(currency || pair) && (balance || selectedCurrencyBalance) ? 'pointer' : 'auto',
+      }}
+    >
+      <UppercaseHelper>
+        {!hideBalance && !!(currency || pair) && (balance || selectedCurrencyBalance) && (
+          <>
+            {customBalanceText ? (
+              <>
+                {customBalanceText}
+                <UnderlinedSmallText as="span" color="text3" fontWeight={600}>
+                  {trimmedBalance}
+                </UnderlinedSmallText>
+              </>
+            ) : (
+              <Trans
+                i18nKey="balance"
+                values={{
+                  balanceInput: trimmedBalance,
+                }}
+                components={[
+                  <span
+                    key="1"
+                    style={{
+                      fontSize: '11px',
+                      color: theme.text3,
+                      fontWeight: 600,
+                      textDecoration: 'underline',
+                    }}
+                  ></span>,
+                ]}
+              />
+            )}
+          </>
+        )}
+      </UppercaseHelper>
+    </TYPE.body>
+  )
 }


### PR DESCRIPTION
# Summary

Fixes #1180

Shou balance on currency input outside swapbox

<img width="489" alt="image" src="https://user-images.githubusercontent.com/23079677/177959324-eb3751e7-bea5-46f7-85a0-1d615ae17783.png">

  # To Test

1. Open any `reward campaign` page where you have LP
2. Click Deposit Stake or any other option related to stake / unstake
- [ ] Verify it shows your LP balance


