### PR TITLE
Remove extra curly brace in toast message when creating campaign

### DIFF
--- a/src/pages/LiquidityMining/Create/index.tsx
+++ b/src/pages/LiquidityMining/Create/index.tsx
@@ -177,7 +177,6 @@ export default function CreateLiquidityMining() {
         addTransaction(transaction, {
           summary: `Create liquidity mining campaign on ${
             stakePair ? `${stakePair.token0.symbol}/${stakePair.token1.symbol}` : stakeToken ? stakeToken.symbol : ''
-          }
           }`,
         })
       })


### PR DESCRIPTION
Fixes #1095 

# Summary

Remove curly brace `{` from toast message for creating campaign
