### PR TITLE
Fix/bridge modal err msg and connext transaction status

### DIFF
--- a/src/services/EcoBridge/Arbitrum/ArbitrumBridge.tsx
+++ b/src/services/EcoBridge/Arbitrum/ArbitrumBridge.tsx
@@ -21,7 +21,7 @@ import {
   EcoBridgeChildBaseInit,
   SyncState,
 } from '../EcoBridge.types'
-import { EcoBridgeChildBase } from '../EcoBridge.utils'
+import { EcoBridgeChildBase, getErrorMsg } from '../EcoBridge.utils'
 import { commonActions } from '../store/Common.reducer'
 import { ecoBridgeUIActions } from '../store/UI.reducer'
 import ARBITRUM_TOKEN_LISTS_CONFIG from './ArbitrumBridge.lists.json'
@@ -29,7 +29,6 @@ import { arbitrumActions } from './ArbitrumBridge.reducer'
 import { arbitrumSelectors } from './ArbitrumBridge.selectors'
 import { hasArbitrumMetadata } from './ArbitrumBridge.types'
 import {
-  getErrorMsg,
   MAX_SUBMISSION_PRICE_PERCENT_INCREASE,
   migrateBridgeTransactions,
   QUERY_ETH_PRICE,
@@ -110,7 +109,7 @@ export class ArbitrumBridge extends EcoBridgeChildBase {
       this.store.dispatch(
         ecoBridgeUIActions.setBridgeModalStatus({
           status: BridgeModalStatus.ERROR,
-          error: getErrorMsg(err),
+          error: getErrorMsg(err, this.bridgeId),
         })
       )
     }
@@ -127,7 +126,7 @@ export class ArbitrumBridge extends EcoBridgeChildBase {
       this.store.dispatch(
         ecoBridgeUIActions.setBridgeModalStatus({
           status: BridgeModalStatus.ERROR,
-          error: getErrorMsg(err),
+          error: getErrorMsg(err, this.bridgeId),
         })
       )
     }
@@ -203,7 +202,7 @@ export class ArbitrumBridge extends EcoBridgeChildBase {
       this.store.dispatch(
         ecoBridgeUIActions.setBridgeModalStatus({
           status: BridgeModalStatus.ERROR,
-          error: getErrorMsg(err),
+          error: getErrorMsg(err, this.bridgeId),
         })
       )
     }

--- a/src/services/EcoBridge/Arbitrum/ArbitrumBridge.utils.ts
+++ b/src/services/EcoBridge/Arbitrum/ArbitrumBridge.utils.ts
@@ -32,11 +32,4 @@ export const QUERY_ETH_PRICE = gql`
   }
 `
 
-export const getErrorMsg = (error: any) => {
-  if (error?.code === 4001) {
-    return 'Transaction rejected'
-  }
-  return `Bridge failed: ${error.message}`
-}
-
 export const MAX_SUBMISSION_PRICE_PERCENT_INCREASE = BigNumber.from(400)

--- a/src/services/EcoBridge/Connext/Connext.ts
+++ b/src/services/EcoBridge/Connext/Connext.ts
@@ -22,7 +22,7 @@ import {
   EcoBridgeChildBaseInit,
   SyncState,
 } from '../EcoBridge.types'
-import { EcoBridgeChildBase } from '../EcoBridge.utils'
+import { EcoBridgeChildBase, getErrorMsg } from '../EcoBridge.utils'
 import { commonActions } from '../store/Common.reducer'
 import { ecoBridgeUIActions } from '../store/UI.reducer'
 import { connextSdkChainConfig } from './Connext.config'
@@ -36,13 +36,6 @@ import {
   ConnextTransactionStatus,
 } from './Connext.types'
 import { getReceivingTransaction, getTransactionsQuery, QUERY_NATIVE_PRICE } from './Connext.utils'
-
-const getErrorMsg = (error: any) => {
-  if (error?.code === 4001) {
-    return 'Transaction rejected'
-  }
-  return `Bridge failed: ${error.message}`
-}
 
 export class Connext extends EcoBridgeChildBase {
   private _connextSdk: NxtpSdk | undefined
@@ -151,7 +144,10 @@ export class Connext extends EcoBridgeChildBase {
       }
     } catch (e) {
       this.store.dispatch(
-        ecoBridgeUIActions.setBridgeModalStatus({ status: BridgeModalStatus.ERROR, error: getErrorMsg(e) })
+        ecoBridgeUIActions.setBridgeModalStatus({
+          status: BridgeModalStatus.ERROR,
+          error: getErrorMsg(e, this.bridgeId),
+        })
       )
     }
   }
@@ -236,7 +232,10 @@ export class Connext extends EcoBridgeChildBase {
       }
     } catch (e) {
       this.store.dispatch(
-        ecoBridgeUIActions.setBridgeModalStatus({ status: BridgeModalStatus.ERROR, error: getErrorMsg(e) })
+        ecoBridgeUIActions.setBridgeModalStatus({
+          status: BridgeModalStatus.ERROR,
+          error: getErrorMsg(e, this.bridgeId),
+        })
       )
     }
   }
@@ -373,7 +372,10 @@ export class Connext extends EcoBridgeChildBase {
       this.store.dispatch(ecoBridgeUIActions.setBridgeModalStatus({ status: BridgeModalStatus.INITIATED }))
     } catch (e) {
       this.store.dispatch(
-        ecoBridgeUIActions.setBridgeModalStatus({ status: BridgeModalStatus.ERROR, error: getErrorMsg(e) })
+        ecoBridgeUIActions.setBridgeModalStatus({
+          status: BridgeModalStatus.ERROR,
+          error: getErrorMsg(e, this.bridgeId),
+        })
       )
     }
   }

--- a/src/services/EcoBridge/EcoBridge.config.ts
+++ b/src/services/EcoBridge/EcoBridge.config.ts
@@ -56,15 +56,14 @@ export const ecoBridgePersistedKeys = ecoBridgeConfig.map(
 )
 
 export const fixCorruptedEcoBridgeLocalStorageEntries = (persistenceNamespace: string) => {
-  const isEntityAdapter = /^{"ids":\[/g
-
   const keysWithoutSocket = ecoBridgePersistedKeys.filter(key => !key.includes(socketBridgeId))
 
   keysWithoutSocket.forEach(key => {
     const fullKey = `${persistenceNamespace}_${key}`
-    const entry = window.localStorage.getItem(fullKey)
 
-    if (entry && !isEntityAdapter.test(entry)) {
+    const isEntityAdapter = window.localStorage.getItem(fullKey)?.includes('entities')
+
+    if (!isEntityAdapter) {
       console.warn(`${fullKey} uses legacy store interface. It was cleared to preserve compatibility.`)
       window.localStorage.removeItem(fullKey)
     }

--- a/src/services/EcoBridge/EcoBridge.utils.tsx
+++ b/src/services/EcoBridge/EcoBridge.utils.tsx
@@ -59,3 +59,26 @@ export abstract class EcoBridgeChildBase {
   abstract fetchDynamicLists(): Promise<void>
   abstract getBridgingMetadata(): void
 }
+
+const getIndexOfSpecialCharacter = (message: string) => {
+  for (let index = 0; index < message.length; index++) {
+    if ("/[!@#$%^&*()_+-=[]{};':\\|,.<>/?]+/".indexOf(message[index]) !== -1) return index
+  }
+  return
+}
+
+const reduceMessage = (message?: string) => {
+  if (!message) return ''
+
+  return message.slice(0, getIndexOfSpecialCharacter(message))
+}
+
+export const getErrorMsg = (error: any, bridgeId: BridgeList) => {
+  if (error?.code === 4001) {
+    return 'Transaction rejected'
+  }
+  if (bridgeId === 'socket' && error.status === 500 && !error.ok) {
+    return 'Socket API is temporarily unavailable'
+  }
+  return `Bridge failed: ${reduceMessage(error.message)}`
+}

--- a/src/services/EcoBridge/OmniBridge/OmniBridge.ts
+++ b/src/services/EcoBridge/OmniBridge/OmniBridge.ts
@@ -19,7 +19,7 @@ import {
   OmniBridgeList,
   SyncState,
 } from '../EcoBridge.types'
-import { EcoBridgeChildBase } from '../EcoBridge.utils'
+import { EcoBridgeChildBase, getErrorMsg } from '../EcoBridge.utils'
 import { ecoBridgeUIActions } from '../store/UI.reducer'
 import { HOME_AMB_ABI } from './abis/abi'
 import { BRIDGE_CONFIG, defaultTokensUrl } from './OmniBridge.config'
@@ -45,7 +45,6 @@ import {
   fetchToAmount,
   fetchTokenLimits,
   fetchToToken,
-  getErrorMessage,
   getGraphEndpoint,
   getMediatorAddress,
   getMessage,
@@ -181,7 +180,10 @@ export class OmniBridge extends EcoBridgeChildBase {
       }
     } catch (e) {
       this.store.dispatch(
-        ecoBridgeUIActions.setBridgeModalStatus({ status: BridgeModalStatus.ERROR, error: getErrorMessage(e) })
+        ecoBridgeUIActions.setBridgeModalStatus({
+          status: BridgeModalStatus.ERROR,
+          error: getErrorMsg(e, this.bridgeId),
+        })
       )
     }
   }
@@ -227,12 +229,9 @@ export class OmniBridge extends EcoBridgeChildBase {
       }
     } catch (e) {
       this.store.dispatch(
-        ecoBridgeUIActions.setStatusButton({
-          label: 'Something went wrong',
-          isError: true,
-          isLoading: false,
-          isBalanceSufficient: false,
-          isApproved: false,
+        ecoBridgeUIActions.setBridgeModalStatus({
+          status: BridgeModalStatus.ERROR,
+          error: getErrorMsg(e, this.bridgeId),
         })
       )
     }
@@ -313,7 +312,10 @@ export class OmniBridge extends EcoBridgeChildBase {
       }
     } catch (e) {
       this.store.dispatch(
-        ecoBridgeUIActions.setBridgeModalStatus({ status: BridgeModalStatus.ERROR, error: getErrorMessage(e) })
+        ecoBridgeUIActions.setBridgeModalStatus({
+          status: BridgeModalStatus.ERROR,
+          error: getErrorMsg(e, this.bridgeId),
+        })
       )
     }
   }

--- a/src/services/EcoBridge/OmniBridge/OmniBridge.utils.ts
+++ b/src/services/EcoBridge/OmniBridge/OmniBridge.utils.ts
@@ -59,14 +59,6 @@ export const QUERY_ETH_PRICE = gql`
   }
 `
 
-//error message
-export const getErrorMessage = (error: any) => {
-  if (error?.code === 4001) {
-    return 'Transaction rejected'
-  }
-  return `Bridge failed: ${error.message}`
-}
-
 //overrides
 const isOverridden = (bridgeDirection: string, token: OmnibridgeTokenWithAddressAndChain) => {
   if (!token || !bridgeDirection) return false

--- a/src/services/EcoBridge/Socket/SocketBridge.ts
+++ b/src/services/EcoBridge/Socket/SocketBridge.ts
@@ -14,7 +14,7 @@ import {
   SocketList,
   SyncState,
 } from '../EcoBridge.types'
-import { EcoBridgeChildBase } from '../EcoBridge.utils'
+import { EcoBridgeChildBase, getErrorMsg } from '../EcoBridge.utils'
 import { commonActions } from '../store/Common.reducer'
 import { ecoBridgeUIActions } from '../store/UI.reducer'
 import { ApprovalsAPI, QuoteAPI, ServerAPI } from './api'
@@ -29,15 +29,6 @@ import { socketSelectors } from './Socket.selectors'
 import { SocketTokenMap, SocketTxStatus } from './Socket.types'
 import { getBestRoute, getStatusOfResponse, overrideTokensAddresses, SOCKET_LISTS_URL, VERSION } from './Socket.utils'
 
-const getErrorMsg = (error: any) => {
-  if (error?.code === 4001) {
-    return 'Transaction rejected'
-  }
-  if (error.status === 500 && !error.ok) {
-    return 'Socket API is temporarily unavailable'
-  }
-  return `Bridge failed: ${error.message}`
-}
 export class SocketBridge extends EcoBridgeChildBase {
   private _tokenLists: SocketTokenMap = {}
   private _listeners: NodeJS.Timeout[] = []
@@ -129,7 +120,10 @@ export class SocketBridge extends EcoBridgeChildBase {
       )
     } catch (e) {
       this.store.dispatch(
-        ecoBridgeUIActions.setBridgeModalStatus({ status: BridgeModalStatus.ERROR, error: getErrorMsg(e) })
+        ecoBridgeUIActions.setBridgeModalStatus({
+          status: BridgeModalStatus.ERROR,
+          error: getErrorMsg(e, this.bridgeId),
+        })
       )
     }
   }
@@ -182,7 +176,10 @@ export class SocketBridge extends EcoBridgeChildBase {
       }
     } catch (e) {
       this.store.dispatch(
-        ecoBridgeUIActions.setBridgeModalStatus({ status: BridgeModalStatus.ERROR, error: getErrorMsg(e) })
+        ecoBridgeUIActions.setBridgeModalStatus({
+          status: BridgeModalStatus.ERROR,
+          error: getErrorMsg(e, this.bridgeId),
+        })
       )
     }
 
@@ -313,7 +310,10 @@ export class SocketBridge extends EcoBridgeChildBase {
       }
     } catch (e) {
       this.store.dispatch(
-        ecoBridgeUIActions.setBridgeModalStatus({ status: BridgeModalStatus.ERROR, error: getErrorMsg(e) })
+        ecoBridgeUIActions.setBridgeModalStatus({
+          status: BridgeModalStatus.ERROR,
+          error: getErrorMsg(e, this.bridgeId),
+        })
       )
     }
   }

--- a/src/services/EcoBridge/Xdai/XdaiBridge.ts
+++ b/src/services/EcoBridge/Xdai/XdaiBridge.ts
@@ -12,7 +12,7 @@ import { DAI, ZERO_ADDRESS } from '../../../constants'
 import ERC20_ABI from '../../../constants/abis/erc20.json'
 import { BridgeTransactionStatus } from '../../../state/bridgeTransactions/types'
 import { SWPRSupportedChains } from '../../../utils/chainSupportsSWPR'
-import { getErrorMsg, QUERY_ETH_PRICE } from '../Arbitrum/ArbitrumBridge.utils'
+import { QUERY_ETH_PRICE } from '../Arbitrum/ArbitrumBridge.utils'
 import {
   BridgeModalStatus,
   EcoBridgeChangeHandler,
@@ -21,7 +21,7 @@ import {
   SyncState,
   XdaiBridgeList,
 } from '../EcoBridge.types'
-import { EcoBridgeChildBase } from '../EcoBridge.utils'
+import { EcoBridgeChildBase, getErrorMsg } from '../EcoBridge.utils'
 import { ecoBridgeUIActions } from '../store/UI.reducer'
 import {
   XDAI_BRIDGE_EXECUTIONS,
@@ -288,7 +288,10 @@ export class XdaiBridge extends EcoBridgeChildBase {
       }
     } catch (e) {
       this.store.dispatch(
-        ecoBridgeUIActions.setBridgeModalStatus({ status: BridgeModalStatus.ERROR, error: getErrorMsg(e) })
+        ecoBridgeUIActions.setBridgeModalStatus({
+          status: BridgeModalStatus.ERROR,
+          error: getErrorMsg(e, this.bridgeId),
+        })
       )
     }
   }
@@ -337,7 +340,10 @@ export class XdaiBridge extends EcoBridgeChildBase {
       }
     } catch (err) {
       this.store.dispatch(
-        ecoBridgeUIActions.setBridgeModalStatus({ status: BridgeModalStatus.ERROR, error: getErrorMsg(err) })
+        ecoBridgeUIActions.setBridgeModalStatus({
+          status: BridgeModalStatus.ERROR,
+          error: getErrorMsg(err, this.bridgeId),
+        })
       )
     }
   }
@@ -394,7 +400,10 @@ export class XdaiBridge extends EcoBridgeChildBase {
           }
         } catch (err) {
           this.store.dispatch(
-            ecoBridgeUIActions.setBridgeModalStatus({ status: BridgeModalStatus.ERROR, error: getErrorMsg(err) })
+            ecoBridgeUIActions.setBridgeModalStatus({
+              status: BridgeModalStatus.ERROR,
+              error: getErrorMsg(err, this.bridgeId),
+            })
           )
         }
       }


### PR DESCRIPTION
# Summary
Fixes #1214

- Reduced error message on bridge modal
- Unified `getErrorMsg` function for bridges
- Fixed transaciton `status` on `Connext`

### `Connext` - incorrect transaction status
#### _Reason_
`fixCorruptedEcoBridgeLocalStorageEntries` method don't work properly.  

#### _Description_: 
We check if bridge uses `entity adapter` because previously bridge used old interface to keep transactions.
```js
// old interface
transactions: {
    chainId: {
        transactions: {}
    }
}
```
After migrate to `entity adapter` when user had old interface in `localStorage` then app was crashing so we created `fixCorruptedEcoBridgeLocalStorageEntries` method which clears `localStorage` and set transactions with new interface for bridge (mostly for `Arbitrum Bridge`).

Unfortunately this method also clears `localStorage` for `Connext` ( weird because `Connext` didn't have old interface ).
After click `collect button` we updated two properties of transaction in `localStorage`:
- `status` to `pending` 
- `isFulfilling` to `true`

Then if user refreshed page,`fixCorruptedEcoBridgeLocalStorageEntries` cleared `localStorage` so we lost details about transaction. After that `fetchHistory` method inside `Connext` fetched transactions from `subgraph` and status of this transaction changed to `collect ->` once again.

 # To Test
- [ ] Check if error message on bridge modal is readable
- [ ] Do a transaction through `Connext` Bridge.
       - Check if `status` after click collect button is `pending`
       - In few minutes `status` of this transaction should change to `collected` (try to break it, e.g refresh page)
       - If `status` is`collected` it should not back to `pending` or `collect ->`


