### PR TITLE
fix / add negative margin for routing through bar to level padding

### DIFF
--- a/src/components/LandingPageComponents/layout/Hero.js
+++ b/src/components/LandingPageComponents/layout/Hero.js
@@ -158,6 +158,8 @@ const Hero = props => {
 const StyledHero = styled(Layout)`
   .routing-through {
     margin-top: auto;
+    margin-left: -16px;
+    margin-right: -16px;
     position: relative;
     z-index: 0;
     &.mobile {


### PR DESCRIPTION
# Summary

Fixes #1202

* Add negative margin for routing through the bar to level padding

Old:
![Selection_154](https://user-images.githubusercontent.com/100695408/178220377-80279ce6-b8ce-4af2-874d-a867e4d4089a.png)

New:
![Selection_153](https://user-images.githubusercontent.com/100695408/178220461-17ee7473-b1e4-44bd-bcf4-da4ddd3f86d0.png)

  # To Test

1. Open the main page
2. Check ROUTING THROUGH bar if margins are ok. Good to check on a bigger screen and different background then black


