### PR TITLE
increase poolTokenPercentage shown on user liquidity to 5 decimals

### DIFF
--- a/src/components/Pool/PairView/UserLiquidity/UserLiquidity.tsx
+++ b/src/components/Pool/PairView/UserLiquidity/UserLiquidity.tsx
@@ -65,7 +65,7 @@ export function UserLiquidity({ pair }: UserLiquidityProps) {
         <InfoGrid>
           <ValueWithLabel
             title={t('poolShare')}
-            value={poolTokenPercentage ? poolTokenPercentage.toFixed(2) + '%' : '0'}
+            value={poolTokenPercentage ? poolTokenPercentage.toFixed(5) + '%' : '0'}
           />
           <ValueWithLabel title={t('poolTokens')} value={userPoolBalance ? userPoolBalance.toSignificant(4) : '0'} />
           <ValueWithLabel


### PR DESCRIPTION
fixes #1228 

<img width="961" alt="image" src="https://user-images.githubusercontent.com/5664434/178316069-ec7d4100-f825-42ac-bffa-30d9781c9988.png">

<img width="926" alt="image" src="https://user-images.githubusercontent.com/5664434/178316055-260f7d2d-60ba-4c96-9920-0dd26539c53a.png">


# Summary

increase poolTokenPercentage shown on user liquidity to 5 decimals

1.  Go to liquidity
- [ ] choose a pool you have shares
2. Check 5 decimals on pool share
