### PR TITLE
remove network name in network switcher

### DIFF
--- a/src/components/Web3Status/AccountStatus.tsx
+++ b/src/components/Web3Status/AccountStatus.tsx
@@ -12,11 +12,9 @@ import EthereumLogo from '../../assets/svg/ethereum-logo.svg'
 import GnosisLogo from '../../assets/svg/gnosis-chain-logo.svg'
 import { CustomNetworkConnector } from '../../connectors/CustomNetworkConnector'
 import { CustomWalletLinkConnector } from '../../connectors/CustomWalletLinkConnector'
-import { ChainLabel } from '../../constants'
 import { ENSAvatarData } from '../../hooks/useENSAvatar'
 import { ApplicationModal } from '../../state/application/actions'
 import { useNetworkSwitcherPopoverToggle } from '../../state/application/hooks'
-import { TYPE } from '../../theme'
 import { shortenAddress } from '../../utils'
 import { TriangleIcon } from '../Icons'
 import Loader from '../Loader'
@@ -97,12 +95,6 @@ const IconWrapper = styled.div<{ size?: number | null }>`
 
   ${({ theme }) => theme.mediaWidth.upToMedium`
     align-items: center;
-  `};
-`
-
-const NetworkName = styled.div`
-  ${({ theme }) => theme.mediaWidth.upToMedium`
-    display: none;
   `};
 `
 
@@ -202,13 +194,6 @@ export function AccountStatus({
           <IconWrapper size={20}>
             <img src={ChainLogo[networkConnectorChainId]} alt="chain logo" />
           </IconWrapper>
-          {account && (
-            <NetworkName>
-              <TYPE.white ml="8px" fontWeight={700} fontSize="12px">
-                {ChainLabel[networkConnectorChainId]}
-              </TYPE.white>
-            </NetworkName>
-          )}
           {networkSwitchingActive && <TriangleIcon />}
         </Web3StatusNetwork>
       </NetworkSwitcherPopover>


### PR DESCRIPTION
# Summary

Fixes #1231

# To Test

1. Open the `Swapr`
- [ ] Name of connected network should not be visible




