### PR TITLE
Update socket domain. Previous domain will be deprecated 

### DIFF
--- a/src/services/EcoBridge/Socket/api/index.ts
+++ b/src/services/EcoBridge/Socket/api/index.ts
@@ -10,7 +10,7 @@ import {
 } from './generated'
 
 const config = new Configuration({
-  basePath: 'https://backend.movr.network',
+  basePath: 'https://api.socket.tech',
   middleware: [
     {
       pre: async ctx => {


### PR DESCRIPTION
# Summary

closes #1140 

Socket has migrated it's API domain to `api.socket.tech`. The previous domain `backend.movr.network` will be deprecated going forward. 

<img width="813" alt="image" src="https://user-images.githubusercontent.com/5664434/178726893-3ede1b3b-d982-4d61-9522-a2dd7a9b0d17.png">


Check [Socket docs](https://docs.socket.tech/socket-api/versioning)

  # To Test

1. Open bridge page
	- [ ] select gnosis to arbitrum
	- [ ] Choose socket to do the bridge
	- [ ] Should work correctly

