### PR TITLE
Fix/1230 switcher cleanup

### DIFF
--- a/src/components/NetworkSwitcher/Option.tsx
+++ b/src/components/NetworkSwitcher/Option.tsx
@@ -31,6 +31,7 @@ const OptionCardClickable = styled(OptionCard)`
   transition: border 0.3s ease;
   color: white;
   cursor: pointer;
+  margin-bottom: 8px;
 
   &:disabled {
     cursor: not-allowed;

--- a/src/components/Web3Status/AccountStatus.tsx
+++ b/src/components/Web3Status/AccountStatus.tsx
@@ -185,7 +185,7 @@ export function AccountStatus({
           )}
         </Web3StatusConnected>
       )}
-      <NetworkSwitcherPopover modal={ApplicationModal.NETWORK_SWITCHER}>
+      <NetworkSwitcherPopover modal={ApplicationModal.NETWORK_SWITCHER} placement="bottom-end">
         <Web3StatusNetwork
           clickable={networkSwitchingActive}
           onClick={networkSwitchingActive ? toggleNetworkSwitcherPopover : undefined}

--- a/src/constants/index.tsx
+++ b/src/constants/index.tsx
@@ -622,7 +622,7 @@ export const OLD_SWPR: { [key: number]: Token } = {
 }
 
 export const TESTNETS = [4, 421611]
-export const SHOW_TESTNETS = true
+export const SHOW_TESTNETS = false
 
 // addresses to filter by when querying for verified KPI tokens
 export const KPI_TOKEN_CREATORS: { [key: number]: string[] } = {

--- a/src/pages/Bridge/index.tsx
+++ b/src/pages/Bridge/index.tsx
@@ -12,7 +12,6 @@ import {
   NetworkSwitcherTags,
 } from '../../components/NetworkSwitcher'
 import { RowBetween } from '../../components/Row'
-import { SHOW_TESTNETS } from '../../constants'
 import { useActiveWeb3React } from '../../hooks'
 import {
   useBridgeActionHandlers,
@@ -254,8 +253,8 @@ export default function Bridge() {
             <AssetWrapper ref={fromPanelRef}>
               <AssetSelector
                 label="from"
-                onClick={SHOW_TESTNETS ? () => setShowFromList(val => !val) : () => null}
-                disabled={SHOW_TESTNETS ? isCollecting : true}
+                onClick={() => setShowFromList(val => !val)}
+                disabled={isCollecting}
                 networkOption={getNetworkOptions({
                   chainId: isCollecting && collectableTx ? collectableTx.fromChainId : fromChainId,
                   networkList: fromNetworkList,
@@ -265,8 +264,8 @@ export default function Bridge() {
                 networksList={fromNetworkList}
                 showWalletConnector={false}
                 parentRef={fromPanelRef}
-                show={SHOW_TESTNETS ? showFromList : false}
-                onOuterClick={SHOW_TESTNETS ? () => setShowFromList(false) : () => null}
+                show={showFromList}
+                onOuterClick={() => setShowFromList(false)}
                 placement="bottom"
               />
             </AssetWrapper>
@@ -276,8 +275,8 @@ export default function Bridge() {
             <AssetWrapper ref={toPanelRef}>
               <AssetSelector
                 label="to"
-                onClick={SHOW_TESTNETS ? () => setShowToList(val => !val) : () => null}
-                disabled={SHOW_TESTNETS ? isCollecting : true}
+                onClick={() => setShowToList(val => !val)}
+                disabled={isCollecting}
                 networkOption={getNetworkOptions({
                   chainId: isCollecting && collectableTx ? collectableTx.toChainId : toChainId,
                   networkList: toNetworkList,
@@ -287,8 +286,8 @@ export default function Bridge() {
                 networksList={toNetworkList}
                 showWalletConnector={false}
                 parentRef={toPanelRef}
-                show={SHOW_TESTNETS ? showToList : false}
-                onOuterClick={SHOW_TESTNETS ? () => setShowToList(false) : () => null}
+                show={showToList}
+                onOuterClick={() => setShowToList(false)}
                 placement="bottom"
               />
             </AssetWrapper>

--- a/src/utils/networksList.ts
+++ b/src/utils/networksList.ts
@@ -101,7 +101,7 @@ export const createNetworksList = ({
   }
 
   return networks
-    .filter(network => SHOW_TESTNETS || !TESTNETS.includes(network.chainId))
+    .filter(network => SHOW_TESTNETS || !TESTNETS.includes(network.chainId) || network.chainId === activeChainId)
     .reduce<NetworksList[]>((taggedList, currentNet) => {
       const tag = currentNet.tag
       const networkPreset = currentNet


### PR DESCRIPTION
# Summary

Fixes #1230 

# To Test

- [ ] Open the network switcher
    - testnets should be hidden
    - space between networks should be larger
- [ ] Go to `Bridge` page
    - check if network switcher works correctly
    ![image](https://user-images.githubusercontent.com/46563377/178753031-8700ff17-18bd-43e2-8708-d19440b92499.png)
- [ ] Connect to testnet (`Arbitrum Rinkeby` or `Rinkeby`) through wallet 
    - testnet should be visible in network swticher 
    ![image](https://user-images.githubusercontent.com/46563377/178756596-64867600-874d-48e9-a04d-21c2607aa5fe.png)
- [ ] Check behavior of network switcher on `mobile` view