### PR TITLE
Only run nessasary CI for dependabot PR's

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,4 +15,9 @@ updates:
     versioning-strategy: increase
     open-pull-requests-limit: 50
     labels:
+      - 'npm'
       - 'dependencies'
+    reviewers:
+      - 'niemam29'
+      - 'MilanVojnovic95'
+      - 'wixzi'

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   chromatic-deployment:
     runs-on: ubuntu-latest
-    if: ${{ !github.event.pull_request.draft }}
+    if: (!github.event.pull_request.draft && github.actor != 'dependabot[bot]')
     steps:
       - uses: actions/checkout@v1
       - name: Install dependencies

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,9 +1,8 @@
 name: 'Chromatic'
 
 on:
-  push:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review, converted_to_draft]
+    types: [opened, synchronize, reopened]
 
 jobs:
   chromatic-deployment:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,7 +256,6 @@ jobs:
 
   cypress:
     name: 🎡 ・Cypress (${{ matrix.containers }})
-    if: github.actor != 'dependabot[bot]'
     needs: install
     runs-on: ubuntu-20.04
     container: swapr/cypress:zstd
@@ -296,7 +295,6 @@ jobs:
 
   cypress-report:
     name: ⬡・Merge and generate cypress reports
-    if: github.actor != 'dependabot[bot]'
     needs: [install, cypress, synpress]
     runs-on: ubuntu-20.04
     steps:
@@ -380,6 +378,7 @@ jobs:
             TransactionSettingsTests
             transactionless
             transactionfull
+
   depcleanup:
     name: 🧹 Dependabot Cleanup
     if: ${{ github.actor == 'dependabot[bot]' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,7 +150,7 @@ jobs:
     name: ⬡・IPFS Deploy
     needs: build
     runs-on: ubuntu-20.04
-    if: ${{ github.event_name != 'schedule' }}
+    if: github.event_name != 'schedule' || github.actor != 'dependabot[bot]'
     steps:
       - name: Inject slug variables
         uses: rlespinasse/github-slug-action@4.2.5
@@ -198,6 +198,7 @@ jobs:
   synpress:
     name: 👘 ・Synpress
     runs-on: ubuntu-20.04
+    if: github.actor != 'dependabot[bot]'
     env:
       TEST_PARAMS: "-s 'tests/synpress/specs/${{ matrix.containers }}/*/*.ts'"
       PRIVATE_KEY: ${{ secrets.TEST_WALLET_PRIVATE_KEY }}
@@ -255,6 +256,7 @@ jobs:
 
   cypress:
     name: 🎡 ・Cypress (${{ matrix.containers }})
+    if: github.actor != 'dependabot[bot]'
     needs: install
     runs-on: ubuntu-20.04
     container: swapr/cypress:zstd
@@ -294,6 +296,7 @@ jobs:
 
   cypress-report:
     name: ⬡・Merge and generate cypress reports
+    if: github.actor != 'dependabot[bot]'
     needs: [install, cypress, synpress]
     runs-on: ubuntu-20.04
     steps:
@@ -377,12 +380,22 @@ jobs:
             TransactionSettingsTests
             transactionless
             transactionfull
+  depcleanup:
+    name: 🧹 Dependabot Cleanup
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    needs: [install, lint, test, typecheck, build]
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Delete workspace artifact
+        uses: geekyeggo/delete-artifact@v1
+        with:
+          name: workspace
 
   cleanup:
     name: 🧹 Cleanup
+    if: ${{ success() && github.actor != 'dependabot[bot]' }}
     needs: [install, lint, test, typecheck, build, cypress, cypress-report]
     runs-on: ubuntu-20.04
-    if: ${{ success() }}
     steps:
       - name: Delete workspace artifact
         uses: geekyeggo/delete-artifact@v1


### PR DESCRIPTION
# Summary

Only run nessasary CI for dependabot PR's

  # To Test

Once merge new Dependabot PR's should not run all the CI tests
