### PR TITLE
fix: add data-testid slippage-error

### DIFF
--- a/src/components/TransactionSettings/index.tsx
+++ b/src/components/TransactionSettings/index.tsx
@@ -103,7 +103,7 @@ const useValidateTransactionSettings = (
 }
 
 const SlippageToleranceError = ({ errorMessage, isInputValid }: { errorMessage: string; isInputValid: boolean }) => (
-  <SlippageErrorInner isInputValid={isInputValid}>
+  <SlippageErrorInner data-testid="slippage-error" isInputValid={isInputValid}>
     <SlippageErrorInnerAlertTriangle isInputValid={isInputValid}>
       <AlertTriangle size={20} />
     </SlippageErrorInnerAlertTriangle>
@@ -263,7 +263,6 @@ export const TransactionSettings = ({
         </RowBetween>
         {slippageError ? (
           <SlippageToleranceError
-            data-testid="slippage-error"
             errorMessage={getSlippageErrorMessage(slippageError)}
             isInputValid={isSlippageInputValid}
           />


### PR DESCRIPTION
# Summary

Add `data-testid="slippage-error"` for slippage error message component.

![image](https://user-images.githubusercontent.com/88723742/182396422-b2a74b8b-166f-4c79-b304-0dad820d8e65.png)


  # To Test

1. Open transaction settings and set slippage tolerance value to show warning/error message box.
- [ ] data-testid for component is rendered
