### PR TITLE
fix: bridge backText message key

### DIFF
--- a/src/pages/Bridge/BridgeModal/BridgeModalContent.tsx
+++ b/src/pages/Bridge/BridgeModal/BridgeModalContent.tsx
@@ -99,7 +99,7 @@ export const BridgeModalContent = ({
                     {text}
                   </TYPE.Main>
                   <ButtonPrimary data-testid="close-bridge-initiated-button" onClick={onDismiss}>
-                    {t('bridgeBackText')}
+                    {t('bridge.backText')}
                   </ButtonPrimary>
                 </>
               )}


### PR DESCRIPTION
# Summary

Fix backText button message

# To Test

1. Go to bridge page and bridge asset
- [ ] "Bridging initiated" modal should have clean texts

