### PR TITLE
[README] Add GitPOAP Badge to Display Number of Minted GitPOAPs for Contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Swapr dapp
 
 [![CI](https://github.com/levelkdev/swapr-dapp/workflows/CI/badge.svg)](https://github.com/levelkdev/swapr-dapp/actions?query=branch%3Adevelop+workflow%3ACI)
+[![GitPOAP Badge](https://public-api.gitpoap.io/v1/repo/levelkdev/swapr-dapp/badge)](https://www.gitpoap.io/gh/levelkdev/swapr-dapp)
 
 An open source decentralized application for Swapr -- a protocol for decentralized exchange of Ethereum tokens governed by the DXdao.
 


### PR DESCRIPTION
# Summary

Hey all, this PR adds a [GitPOAP Badge](https://docs.gitpoap.io/api#get-v1repoownernamebadge) to the README that displays the number of minted GitPOAPs for this repository by contributors to this repo.

You can see an example of this in [our Documentation repository](https://github.com/gitpoap/gitpoap-docs#gitpoap-docs).

This should help would-be contributors as well as existing contributors find out that they will/have received GitPOAPs for their contributions.

CC: @colfax23 @kayla-henrie

  # Background

GitPOAPs have been issued for repos in the DXdao codebase

