### PR TITLE
fix: use native currency price

### DIFF
--- a/src/hooks/useUSDValue.ts
+++ b/src/hooks/useUSDValue.ts
@@ -87,7 +87,7 @@ export function useUSDPrice(tokenAmount?: TokenAmount) {
   }, [chainId, tokenAmount, stablecoin, tradeExactInUniswapV2])
 }
 
-export function useCoingeckoUSDPrice(token?: Token, isNativeCurrency: boolean = false) {
+export function useCoingeckoUSDPrice(token?: Token, isNativeCurrency = false) {
   // default to MAINNET (if disconnected e.g)
   const { chainId = ChainId.MAINNET } = useActiveWeb3React()
   const [price, setPrice] = useState<Price | undefined>()
@@ -198,7 +198,7 @@ export function useUSDValue(tokenAmount?: TokenAmount) {
   return useGetPriceQuote({ price: price, tokenAmount: tokenAmount })
 }
 
-export function useCoingeckoUSDValue(tokenAmount?: TokenAmount, isNativeCurrency: boolean = false) {
+export function useCoingeckoUSDValue(tokenAmount?: TokenAmount, isNativeCurrency = false) {
   const coingeckoUsdPrice = useCoingeckoUSDPrice(tokenAmount?.token, isNativeCurrency)
 
   return useGetPriceQuote({

--- a/src/hooks/useUSDValue.ts
+++ b/src/hooks/useUSDValue.ts
@@ -16,7 +16,7 @@ import { useEffect, useMemo, useRef, useState } from 'react'
 
 import { DAI, USDC } from '../constants/index'
 import { tryParseAmount } from '../state/swap/hooks'
-import { getUSDPriceQuote, toPriceInformation } from '../utils/coingecko'
+import { getUSDPriceCurrencyQuote, getUSDPriceTokenQuote, toPriceInformation } from '../utils/coingecko'
 import { currencyId } from '../utils/currencyId'
 import { wrappedCurrencyAmount } from '../utils/wrappedCurrency'
 import { useTradeExactInUniswapV2 } from './Trades'
@@ -35,7 +35,7 @@ const FETCH_PRICE_INTERVAL = 15000
 const convertToTokenAmount = (currencyAmount: CurrencyAmount | undefined, chainId: ChainId) => {
   if (!currencyAmount) return
 
-  if (Currency.isNative(currencyAmount?.currency)) return wrappedCurrencyAmount(currencyAmount, chainId)
+  if (Currency.isNative(currencyAmount.currency)) return wrappedCurrencyAmount(currencyAmount, chainId)
 
   if (!currencyAmount.currency.address) return
 
@@ -87,7 +87,7 @@ export function useUSDPrice(tokenAmount?: TokenAmount) {
   }, [chainId, tokenAmount, stablecoin, tradeExactInUniswapV2])
 }
 
-export function useCoingeckoUSDPrice(token?: Token) {
+export function useCoingeckoUSDPrice(token?: Token, isNativeCurrency: boolean = false) {
   // default to MAINNET (if disconnected e.g)
   const { chainId = ChainId.MAINNET } = useActiveWeb3React()
   const [price, setPrice] = useState<Price | undefined>()
@@ -99,17 +99,21 @@ export function useCoingeckoUSDPrice(token?: Token) {
   tokenRef.current = token
 
   const tokenAddress = token ? currencyId(token) : undefined
-
   useEffect(() => {
     const fetchPrice = () => {
       const baseAmount = tryParseAmount('1', tokenRef.current)
 
       if (!chainId || !tokenAddress || !baseAmount) return
 
-      getUSDPriceQuote({
-        chainId,
-        tokenAddress,
-      })
+      let getUSDPriceQuote
+
+      if (isNativeCurrency) {
+        getUSDPriceQuote = getUSDPriceCurrencyQuote({ chainId })
+      } else {
+        getUSDPriceQuote = getUSDPriceTokenQuote({ tokenAddress, chainId })
+      }
+
+      getUSDPriceQuote
         .then(toPriceInformation)
         .then(priceResponse => {
           setError(undefined)
@@ -164,7 +168,7 @@ export function useCoingeckoUSDPrice(token?: Token) {
       clearInterval(refetchPrice)
     }
     // don't depend on token (deep nested object)
-  }, [chainId, tokenAddress])
+  }, [chainId, tokenAddress, isNativeCurrency])
 
   return { price, error }
 }
@@ -194,8 +198,8 @@ export function useUSDValue(tokenAmount?: TokenAmount) {
   return useGetPriceQuote({ price: price, tokenAmount: tokenAmount })
 }
 
-export function useCoingeckoUSDValue(tokenAmount?: TokenAmount) {
-  const coingeckoUsdPrice = useCoingeckoUSDPrice(tokenAmount?.token)
+export function useCoingeckoUSDValue(tokenAmount?: TokenAmount, isNativeCurrency: boolean = false) {
+  const coingeckoUsdPrice = useCoingeckoUSDPrice(tokenAmount?.token, isNativeCurrency)
 
   return useGetPriceQuote({
     ...coingeckoUsdPrice,
@@ -214,12 +218,14 @@ export function useHigherUSDValue({
 
   const inputTokenAmount = convertToTokenAmount(inputCurrencyAmount, chainId)
   const outputTokenAmount = convertToTokenAmount(outputCurrencyAmount, chainId)
+  const inputIsNativeCurrency = inputCurrencyAmount && Currency.isNative(inputCurrencyAmount?.currency)
+  const outputIsNativeCurrency = outputCurrencyAmount && Currency.isNative(outputCurrencyAmount?.currency)
 
   const inputUSDPrice = useUSDValue(inputTokenAmount)
   const outputUSDPrice = useUSDValue(outputTokenAmount)
 
-  const inputCoingeckoUSDPrice = useCoingeckoUSDValue(inputTokenAmount)
-  const outputCoingeckoUSDPrice = useCoingeckoUSDValue(outputTokenAmount)
+  const inputCoingeckoUSDPrice = useCoingeckoUSDValue(inputTokenAmount, inputIsNativeCurrency)
+  const outputCoingeckoUSDPrice = useCoingeckoUSDValue(outputTokenAmount, outputIsNativeCurrency)
 
   return {
     fiatValueInput: inputCoingeckoUSDPrice || inputUSDPrice,

--- a/src/utils/coingecko.ts
+++ b/src/utils/coingecko.ts
@@ -75,8 +75,8 @@ export async function getUSDPriceTokenQuote(params: CoinGeckoUsdPriceTokenParams
   const { chainId, tokenAddress } = params
 
   const assetPlatform = COINGECKO_ASSET_PLATFORM[chainId]
-  if (assetPlatform == null) {
-    // Unsupported
+  if (!assetPlatform) {
+    // Unsupported asset network
     return null
   }
 
@@ -97,8 +97,8 @@ export async function getUSDPriceCurrencyQuote(
   const { chainId } = params
 
   const nativeCurrency = COINGECKO_NATIVE_CURRENCY[chainId]
-  if (nativeCurrency == null) {
-    // Unsupported
+  if (!nativeCurrency) {
+    // Unsupported currency network
     return null
   }
 


### PR DESCRIPTION
# Summary

Fixes #1283

Use Coingecko to fetch native currency prices

# To Test

1. Simulate trade with native currency
- [ ] Check if native currency USD price is equal to Coingecko price