### PR TITLE
Fix: 1343 set only on mobile smaller logo and bigger gap for settings

### DIFF
--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -16,6 +16,7 @@ import { ApplicationModal } from '../../state/application/actions'
 import { useModalOpen, useToggleShowClaimPopup, useToggleShowExpeditionsPopup } from '../../state/application/hooks'
 import { useDarkModeManager } from '../../state/user/hooks'
 import { useTokenBalance } from '../../state/wallet/hooks'
+import { breakpoints } from '../../utils/theme'
 import ClaimModal from '../claim/ClaimModal'
 import ExpeditionsModal from '../expeditions/ExpeditionsModal'
 import { UnsupportedNetworkPopover } from '../NetworkUnsupportedPopover'
@@ -186,6 +187,10 @@ const AdditionalDataWrap = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: end;
+
+  @media screen and (max-width: ${breakpoints.s}) {
+    gap: 15px;
+  }
 `
 const StyledChevron = styled(ChevronUp)<{ open: boolean }>`
   stroke: ${({ theme }) => theme.orange1};

--- a/src/components/SwaprVersionLogo/index.tsx
+++ b/src/components/SwaprVersionLogo/index.tsx
@@ -2,9 +2,14 @@ import styled from 'styled-components'
 
 import packageJson from '../../../package.json'
 import logoImage from '../../assets/svg/swapr_white_no_badge.svg'
+import { breakpoints } from '../../utils/theme'
 
 const Logo = styled.img.attrs({ src: logoImage })`
   height: 40px;
+
+  @media screen and (max-width: ${breakpoints.s}) {
+    height: 34px;
+  }
 `
 
 const RelativeContainer = styled.div`


### PR DESCRIPTION
# Summary

Fixes #1343 

Set for mobile smaller logo and bigger gap for the settings

![Selection_190](https://user-images.githubusercontent.com/100695408/183597145-0be6a212-87ee-428a-a932-cc003b14b244.png)



  # To Test

1. Open any page where 'Expeditions' button is displayed
2. Check mobile design if button is not overlapping logo


