### PR TITLE
Fix: 1344 add spacing for the text in swap button 

### DIFF
--- a/src/components/swap/SwapButtons/SwapButton.tsx
+++ b/src/components/swap/SwapButtons/SwapButton.tsx
@@ -1,8 +1,8 @@
 import shuffle from 'lodash/shuffle'
 import { useTranslation } from 'react-i18next'
-import { Box, Flex, Text } from 'rebass'
+import { Flex, Text } from 'rebass'
 import { ButtonProps } from 'rebass/styled-components'
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 
 import {
   PRICE_IMPACT_HIGH,
@@ -17,6 +17,10 @@ import { ButtonPrimary } from '../../Button'
 const StyledSwapButton = styled(ButtonPrimary)<{ gradientColor: string }>`
   background-image: ${({ gradientColor, disabled }) =>
     !disabled && gradientColor && `linear-gradient(90deg, #2E17F2 19.74%, ${gradientColor} 120.26%)`};
+
+  ${({ theme }) => theme.mediaWidth.upToExtraSmall`
+    padding: 1rem 0.5rem;
+  `};
 `
 
 const StyledSwapLoadingButton = styled(ButtonPrimary)`
@@ -52,9 +56,27 @@ const LogoWithText = styled.div`
   justify-content: center;
 `
 
-const StyledPlataformText = styled(Text)`
-  text-transform: none;
+const UnifyFontSize = css`
   font-size: 15px;
+
+  ${({ theme }) => theme.mediaWidth.upToExtraSmall`
+    font-size: 13px;
+  `};
+`
+
+const StyledPlatformText = styled.div`
+  text-transform: none;
+  margin-left: 0.5rem;
+  ${UnifyFontSize}
+`
+
+const UnifiedText = styled(Text)`
+  ${UnifyFontSize}
+`
+
+const AnywayText = styled.span`
+  margin-left: 0.5rem;
+  ${UnifyFontSize}
 `
 
 interface SwapButtonProps {
@@ -94,8 +116,8 @@ export const SwapButton = ({
         ) : priceImpactSeverity > PRICE_IMPACT_HIGH && !isExpertMode ? (
           t('button.priceImpactTooHigh')
         ) : (
-          <Flex alignItems="center">
-            <Text fontSize="15px">{t('button.swapWith')}</Text>
+          <Flex alignItems="center" justifyContent="center" flexWrap="wrap">
+            <UnifiedText>{t('button.swapWith')}</UnifiedText>
             {platformName && (
               <Flex alignItems="center" marginLeft={2}>
                 <img
@@ -104,12 +126,10 @@ export const SwapButton = ({
                   width={21}
                   height={21}
                 />
-                <Box marginLeft={2}>
-                  <StyledPlataformText>{ROUTABLE_PLATFORM_STYLE[platformName].name}</StyledPlataformText>
-                </Box>
+                <StyledPlatformText>{ROUTABLE_PLATFORM_STYLE[platformName].name}</StyledPlatformText>
               </Flex>
             )}
-            {priceImpactSeverity > PRICE_IMPACT_MEDIUM && ` ${t('button.anyway')}`}
+            <AnywayText>{priceImpactSeverity > PRICE_IMPACT_MEDIUM && t('button.anyway')}</AnywayText>
           </Flex>
         )}
       </Text>

--- a/src/components/swap/SwapButtons/SwapButton.tsx
+++ b/src/components/swap/SwapButtons/SwapButton.tsx
@@ -65,7 +65,7 @@ const UnifyFontSize = css`
 `
 
 const StyledPlatformText = styled.div`
-  text-transform: none;
+  text-transform: uppercase;
   margin-left: 0.5rem;
   ${UnifyFontSize}
 `


### PR DESCRIPTION
# Summary

Fixes #1344

Add spacing for the text in the swap button and set the smaller font to fit the mobile design

![Selection_191](https://user-images.githubusercontent.com/100695408/183611618-66fbd727-b6b0-4cc0-bacb-f39ac5bf8d76.png)


  # To Test

1. Go to the swap page
2. Select tokens on expert mode to have a high price impact
3. Check the design, also on mobile


