### PR TITLE
Add constraints on build step

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Install dependencies
-        run: yarn
+        run: yarn install --frozen-lockfile
 
       - name: Build
         run: yarn build


### PR DESCRIPTION
# Summary

This PR helps to constrain the command used to install the dapp on the CI pipeline.
Pipeline should not choke on the installation step.

I'm making a specific PR for this as I want this to affect other PRs and actions need to be in the principal branch, in this case develop.