### PR TITLE
Improved getting commit messaged and fix for reruning tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,9 +254,9 @@ jobs:
           echo "TEST_PARAMS=-s 'tests/synpress/specs/${{ matrix.containers }}/*/*.ts'" >> "$GITHUB_ENV"
 
       - name: Check if pr is merged
-        if: ${{ (github.event_name == 'push') }}
+        if: ${{ (github.event_name == 'push') || (contains(needs.prepare.outputs.commit-message,'trigger-synpress-dashboard')) }}
         run: |
-          echo "TEST_PARAMS=-s 'tests/synpress/specs/${{ matrix.containers }}/*/*.ts --record --key=${{ secrets.CYPRESS_DASHBOARD_KEY }} --tag SYNPRESS'"
+          echo "TEST_PARAMS=-s 'tests/synpress/specs/${{ matrix.containers }}/*/*.ts --record --key=${{ secrets.CYPRESS_DASHBOARD_KEY }} --tag SYNPRESS --ci-build-id ${{ needs.prepare.outputs.uuid }}'" >> "$GITHUB_ENV"
 
       - name: ⎔ Setup node
         uses: actions/setup-node@v3
@@ -285,7 +285,6 @@ jobs:
         run: yarn codegen:graphql
 
       - name: Run synpress tests
-        if: ${{ (github.event_name == 'push') || (contains( steps.prepare.commit-message.outputs.value , 'trigger-synpress')) }}
         run: yarn synpress:ct
         continue-on-error: true
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,6 +227,7 @@ jobs:
   synpress:
     name: 👘 ・Synpress
     runs-on: ubuntu-20.04
+    needs: [prepare]
     container: cypress/browsers:node16.5.0-chrome97-ff96
     if: ${{ (contains(steps.commit-message.outputs.value, 'trigger-synpress') || github.event_name == 'push') }}
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -349,7 +349,6 @@ jobs:
           COMMIT_INFO_SHA: ${{github.event.pull_request.head.sha}}
 
       - name: Merge test results into one
-        if: ${{ !(steps.commit-message.outputs.value), 'skip-cypress')) }}
         run: |
           yarn run report:merge
           mv index.json ${{ matrix.containers }}.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -312,7 +312,7 @@ jobs:
     needs: [install, prepare]
     runs-on: ubuntu-20.04
     container: swapr/cypress:zstd
-    if: ${{ needs.prepare.outputs.uuid != 'skip-cypress'}}
+    if: ${{ contains(needs.prepare.outputs.uuid, 'skip-cypress') }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -248,7 +248,7 @@ jobs:
           echo "$GITHUB_CONTEXT"
 
       - name: Check how tests should be executed #1
-        if: contains(steps.commit-message.outputs.value, 'trigger-synpress')
+        if: ${{contains( steps.prepare.commit-message.outputs.value , 'trigger-synpress')}}
         run: |
           echo "TEST_PARAMS=-s 'tests/synpress/specs/${{ matrix.containers }}/*/*.ts'" >> "$GITHUB_ENV"
 
@@ -284,7 +284,7 @@ jobs:
         run: yarn codegen:graphql
 
       - name: Run synpress tests
-        if: ${{ (github.event_name == 'push') || (contains(steps.commit-message.outputs.value, 'trigger-synpress')) }}
+        if: ${{ (github.event_name == 'push') || (contains( steps.prepare.commit-message.outputs.value , 'trigger-synpress')) }}
         run: yarn synpress:ct
         continue-on-error: true
         env:
@@ -293,13 +293,13 @@ jobs:
           COMMIT_INFO_SHA: ${{ github.event.pull_request.head.sha }}
 
       - name: Merge test results into one
-        if: ${{ (github.event_name == 'push') || (contains(steps.commit-message.outputs.value, 'trigger-synpress')) }}
+        if: ${{ (github.event_name == 'push') || (contains(steps.prepare.commit-message.outputs.value, 'trigger-synpress')) }}
         run: |
           yarn run report:merge
           mv index.json ${{ matrix.containers }}.json
 
       - name: Save code coverage results
-        if: ${{ (github.event_name == 'push') || (contains(steps.commit-message.outputs.value, 'trigger-synpress')) }}
+        if: ${{ (github.event_name == 'push') || (contains(steps.prepare.commit-message.outputs.value, 'trigger-synpress')) }}
         uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.containers }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
     runs-on: ubuntu-20.04
     outputs:
       uuid: ${{ steps.uuid.outputs.value }}
+      commit-message: ${{ steps.commit-message.outputs.value }}
     steps:
       - name: ⬇️ ・Checkout repo
         uses: actions/checkout@v3
@@ -446,7 +447,7 @@ jobs:
   cleanup:
     name: 🧹 Cleanup
     if: ${{ success() && github.actor != 'dependabot[bot]' }}
-    needs: [install, lint, test, typecheck, build, cypress, cypress-report]
+    needs: [install, lint, test, typecheck, build]
     runs-on: ubuntu-20.04
     steps:
       - name: Delete workspace artifact

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,7 +229,7 @@ jobs:
     runs-on: ubuntu-20.04
     needs: [prepare]
     container: cypress/browsers:node16.5.0-chrome97-ff96
-    if: ${{ (contains(steps.commit-message.outputs.value, 'trigger-synpress') || github.event_name == 'push') }}
+    if: ${{ (contains(needs.prepare.outputs.commit-message, 'trigger-synpress') || github.event_name == 'push') }}
     env:
       PRIVATE_KEY: ${{ secrets.TEST_WALLET_PRIVATE_KEY }}
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -312,7 +312,6 @@ jobs:
     needs: install
     runs-on: ubuntu-20.04
     container: swapr/cypress:zstd
-    if: ${{ !(contains(env.COMMIT_MSG, 'trigger-cypress')) }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -309,9 +309,10 @@ jobs:
 
   cypress:
     name: 🎡 ・Cypress (${{ matrix.containers }})
-    needs: install
+    needs: [install, prepare]
     runs-on: ubuntu-20.04
     container: swapr/cypress:zstd
+    if: ${{ needs.prepare.outputs.uuid != 'skip-cypress'}}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -442,7 +442,7 @@ jobs:
   cleanup:
     name: 🧹 Cleanup
     if: ${{ success() && github.actor != 'dependabot[bot]' }}
-    needs: [install, lint, test, typecheck, build]
+    needs: [install, lint, test, typecheck, build, cypress, cypress-report]
     runs-on: ubuntu-20.04
     steps:
       - name: Delete workspace artifact

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,9 +31,6 @@ jobs:
 
       - name: Generate unique ID 💎
         id: uuid
-        # take the current commit + timestamp together
-        # the typical value would be something like
-        # "sha-5d3fe...35d3-time-1620841214"
         run: echo "::set-output name=value::sha-$GITHUB_SHA-time-$(date +"%s")"
 
       - name: Get Commit Message
@@ -290,7 +287,7 @@ jobs:
         env:
           CI: true
           COMMIT_INFO_MESSAGE: ${{ github.event.pull_request.title }}
-          COMMIT_INFO_SHA: ${{ github.event.pull_request.head.sha }}
+          COMMIT_INFO_SHA: ${{ needs.prepare.outputs.uuid }}
 
       - name: Merge test results into one
         if: ${{ (github.event_name == 'push') || (contains(steps.prepare.commit-message.outputs.value, 'trigger-synpress')) }}
@@ -333,19 +330,19 @@ jobs:
 
       - name: Run cypress tests
         if: ${{ !(github.event_name == 'push') }}
-        run: yarn cypress:ci './node_modules/.bin/cypress run -r mochawesome --record --group electron --key=${{ secrets.CYPRESS_DASHBOARD_KEY }} --parallel --tag TESTS_FROM_PR --ci-build-id ${{ needs.prepare.outputs.uuid }}'
+        run: yarn cypress:ci './node_modules/.bin/cypress run -r mochawesome --record --group electron --key=${{ secrets.CYPRESS_DASHBOARD_KEY }} --parallel --tag TESTS_FROM_PR'
         continue-on-error: true
         env:
           COMMIT_INFO_MESSAGE: ${{github.event.pull_request.title}}
-          COMMIT_INFO_SHA: ${{github.event.pull_request.head.sha}}
+          COMMIT_INFO_SHA: ${{ needs.prepare.outputs.uuid }}
 
       - name: Run cypress tests after merge
         if: ${{ (github.event_name == 'push') }}
-        run: yarn cypress:ci './node_modules/.bin/cypress run -r mochawesome --record --group electron --key=${{ secrets.CYPRESS_DASHBOARD_KEY }} --parallel --ci-build-id ${{ needs.prepare.outputs.uuid }} --tag SMOKE_TESTS'
+        run: yarn cypress:ci './node_modules/.bin/cypress run -r mochawesome --record --group electron --key=${{ secrets.CYPRESS_DASHBOARD_KEY }} --parallel }} --tag SMOKE_TESTS'
         continue-on-error: true
         env:
           COMMIT_INFO_MESSAGE: ${{github.event.pull_request.title}}
-          COMMIT_INFO_SHA: ${{github.event.pull_request.head.sha}}
+          COMMIT_INFO_SHA: ${{ needs.prepare.outputs.uuid }}
 
       - name: Merge test results into one
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,6 +228,7 @@ jobs:
     name: 👘 ・Synpress
     runs-on: ubuntu-20.04
     container: cypress/browsers:node16.5.0-chrome97-ff96
+    if: ${{ (contains(env.COMMIT_MSG, 'trigger-synpress') || github.event_name == 'push') }}
     env:
       PRIVATE_KEY: ${{ secrets.TEST_WALLET_PRIVATE_KEY }}
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,7 +254,7 @@ jobs:
           echo "TEST_PARAMS=-s 'tests/synpress/specs/${{ matrix.containers }}/*/*.ts'" >> "$GITHUB_ENV"
 
       - name: Check if pr is merged
-        if: ${{ (github.event_name == 'push') || (contains(needs.prepare.outputs.commit-message,'trigger-dashboard-synpress')) }}
+        if: ${{ (github.event_name == 'push') || (contains(needs.prepare.outputs.commit-message,'trigger-synpress-dashboard')) }}
         run: |
           echo "TEST_PARAMS=-s 'tests/synpress/specs/${{ matrix.containers }}/*/*.ts --record --key=${{ secrets.CYPRESS_DASHBOARD_KEY }} --ci-build-id ${{ needs.prepare.outputs.uuid }} --tag SYNPRESS'" >> "$GITHUB_ENV"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,12 +249,11 @@ jobs:
         run: |
           echo "$GITHUB_CONTEXT"
 
-      - name: Check how tests should be executed #1
-        if: ${{contains( steps.prepare.commit-message.outputs.value , 'trigger-synpress')}}
+      - name: Set synpress default params
         run: |
           echo "TEST_PARAMS=-s 'tests/synpress/specs/${{ matrix.containers }}/*/*.ts'" >> "$GITHUB_ENV"
 
-      - name: Check how tests should be executed #2
+      - name: Check if pr is merged
         if: ${{ (github.event_name == 'push') }}
         run: |
           echo "TEST_PARAMS=-s 'tests/synpress/specs/${{ matrix.containers }}/*/*.ts --record --key=${{ secrets.CYPRESS_DASHBOARD_KEY }} --tag SYNPRESS'"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -349,7 +349,7 @@ jobs:
           COMMIT_INFO_SHA: ${{github.event.pull_request.head.sha}}
 
       - name: Merge test results into one
-        if: ${{ !(steps.commit-message.outputs.value, 'skip-cypress')) }}
+        if: ${{ !(steps.commit-message.outputs.value), 'skip-cypress')) }}
         run: |
           yarn run report:merge
           mv index.json ${{ matrix.containers }}.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -253,7 +253,7 @@ jobs:
       - name: Check if synpress should be reported to dashboard
         if: ${{ (github.event_name == 'push') || (contains(needs.prepare.outputs.commit-message,'trigger-synpress-dashboard')) }}
         run: |
-          echo "TEST_PARAMS=-s 'tests/synpress/specs/${{ matrix.containers }}/*/*.ts --record --key=${{ secrets.CYPRESS_DASHBOARD_KEY }} --ci-build-id ${{ needs.prepare.outputs.uuid }} --tag SYNPRESS'" >> "$GITHUB_ENV"
+          echo "TEST_PARAMS=-s 'tests/synpress/specs/${{ matrix.containers }}/*/*.ts --record --key=${{ secrets.CYPRESS_DASHBOARD_KEY }} --tag SYNPRESS'" >> "$GITHUB_ENV"
 
       - name: ⎔ Setup node
         uses: actions/setup-node@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -250,7 +250,7 @@ jobs:
         run: |
           echo "TEST_PARAMS=-s 'tests/synpress/specs/${{ matrix.containers }}/*/*.ts'" >> "$GITHUB_ENV"
 
-      - name: Check if pr is merged
+      - name: Check if synpress should be reported to dashboard
         if: ${{ (github.event_name == 'push') || (contains(needs.prepare.outputs.commit-message,'trigger-synpress-dashboard')) }}
         run: |
           echo "TEST_PARAMS=-s 'tests/synpress/specs/${{ matrix.containers }}/*/*.ts --record --key=${{ secrets.CYPRESS_DASHBOARD_KEY }} --ci-build-id ${{ needs.prepare.outputs.uuid }} --tag SYNPRESS'" >> "$GITHUB_ENV"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,7 +228,7 @@ jobs:
     name: 👘 ・Synpress
     runs-on: ubuntu-20.04
     container: cypress/browsers:node16.5.0-chrome97-ff96
-    if: ${{ (contains(env.COMMIT_MSG, 'trigger-synpress') || github.event_name == 'push') }}
+    if: ${{ (contains(steps.commit-message.outputs.value, 'trigger-synpress') || github.event_name == 'push') }}
     env:
       PRIVATE_KEY: ${{ secrets.TEST_WALLET_PRIVATE_KEY }}
     strategy:
@@ -248,7 +248,7 @@ jobs:
           echo "$GITHUB_CONTEXT"
 
       - name: Check how tests should be executed #1
-        if: contains(env.COMMIT_MSG, 'trigger-synpress')
+        if: contains(steps.commit-message.outputs.value, 'trigger-synpress')
         run: |
           echo "TEST_PARAMS=-s 'tests/synpress/specs/${{ matrix.containers }}/*/*.ts'" >> "$GITHUB_ENV"
 
@@ -284,7 +284,7 @@ jobs:
         run: yarn codegen:graphql
 
       - name: Run synpress tests
-        if: ${{ (github.event_name == 'push') || (contains(env.COMMIT_MSG, 'trigger-synpress')) }}
+        if: ${{ (github.event_name == 'push') || (contains(steps.commit-message.outputs.value, 'trigger-synpress')) }}
         run: yarn synpress:ct
         continue-on-error: true
         env:
@@ -293,13 +293,13 @@ jobs:
           COMMIT_INFO_SHA: ${{ github.event.pull_request.head.sha }}
 
       - name: Merge test results into one
-        if: ${{ (github.event_name == 'push') || (contains(env.COMMIT_MSG, 'trigger-synpress')) }}
+        if: ${{ (github.event_name == 'push') || (contains(steps.commit-message.outputs.value, 'trigger-synpress')) }}
         run: |
           yarn run report:merge
           mv index.json ${{ matrix.containers }}.json
 
       - name: Save code coverage results
-        if: ${{ (github.event_name == 'push') || (contains(env.COMMIT_MSG, 'trigger-synpress')) }}
+        if: ${{ (github.event_name == 'push') || (contains(steps.commit-message.outputs.value, 'trigger-synpress')) }}
         uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.containers }}
@@ -313,7 +313,7 @@ jobs:
     needs: [install, prepare]
     runs-on: ubuntu-20.04
     container: swapr/cypress:zstd
-    if: ${{ contains(needs.prepare.outputs.uuid, 'skip-cypress') }}
+    if: ${{ contains(needs.prepare.outputs.commit-message, 'skip-cypress') }}
     strategy:
       fail-fast: false
       matrix:
@@ -348,7 +348,7 @@ jobs:
           COMMIT_INFO_SHA: ${{github.event.pull_request.head.sha}}
 
       - name: Merge test results into one
-        if: ${{ !(contains(env.COMMIT_MSG, 'skip-cypress')) }}
+        if: ${{ !(steps.commit-message.outputs.value, 'skip-cypress')) }}
         run: |
           yarn run report:merge
           mv index.json ${{ matrix.containers }}.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -333,7 +333,7 @@ jobs:
 
       - name: Run cypress tests
         if: ${{ !(github.event_name == 'push') }}
-        run: yarn cypress:ci './node_modules/.bin/cypress run -r mochawesome --record --group electron --key=${{ secrets.CYPRESS_DASHBOARD_KEY }} --parallel --tag TESTS_FROM_PR'
+        run: yarn cypress:ci './node_modules/.bin/cypress run -r mochawesome --record --group electron --key=${{ secrets.CYPRESS_DASHBOARD_KEY }} --parallel --tag TESTS_FROM_PR --ci-build-id ${{ needs.prepare.outputs.uuid }}'
         continue-on-error: true
         env:
           COMMIT_INFO_MESSAGE: ${{github.event.pull_request.title}}
@@ -341,7 +341,7 @@ jobs:
 
       - name: Run cypress tests after merge
         if: ${{ (github.event_name == 'push') }}
-        run: yarn cypress:ci './node_modules/.bin/cypress run -r mochawesome --record --group electron --key=${{ secrets.CYPRESS_DASHBOARD_KEY }} --parallel --tag SMOKE_TESTS'
+        run: yarn cypress:ci './node_modules/.bin/cypress run -r mochawesome --record --group electron --key=${{ secrets.CYPRESS_DASHBOARD_KEY }} --parallel --tag SMOKE_TESTS --ci-build-id ${{ needs.prepare.outputs.uuid }}'
         continue-on-error: true
         env:
           COMMIT_INFO_MESSAGE: ${{github.event.pull_request.title}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,32 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  prepare:
+    runs-on: ubuntu-20.04
+    outputs:
+      uuid: ${{ steps.uuid.outputs.value }}
+    steps:
+      - name: ⬇️ ・Checkout repo
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: '50'
+
+      - name: Generate unique ID 💎
+        id: uuid
+        # take the current commit + timestamp together
+        # the typical value would be something like
+        # "sha-5d3fe...35d3-time-1620841214"
+        run: echo "::set-output name=value::sha-$GITHUB_SHA-time-$(date +"%s")"
+
+      - name: Get Commit Message
+        id: commit-message
+        run: |
+          MSG=$(git log --format=%B -n 1 ${{github.event.after}})
+          echo "::set-output name=value::$(printf "$MSG" | xargs)"
+      - name: Echo commit message
+        run: echo "${{ steps.commit-message.outputs.value }}"
+  
+
   install:
     name: Install
     runs-on: ubuntu-20.04
@@ -214,11 +240,6 @@ jobs:
         with:
           fetch-depth: '50'
 
-      - name: Get Commit Message
-        run: |
-          MSG=$(git log --format=%B -n 1 ${{github.event.after}})
-          echo "COMMIT_MSG=$(printf "$MSG" | xargs)" >> "$GITHUB_ENV"
-
       - name: Dump GitHub context
         env:
           GITHUB_CONTEXT: ${{ toJson(github) }}
@@ -291,6 +312,7 @@ jobs:
     needs: install
     runs-on: ubuntu-20.04
     container: swapr/cypress:zstd
+    if: ${{ !(contains(env.COMMIT_MSG, 'trigger-cypress')) }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -310,7 +310,7 @@ jobs:
     needs: [install, prepare]
     runs-on: ubuntu-20.04
     container: swapr/cypress:zstd
-    if: ${{ contains(needs.prepare.outputs.commit-message, 'skip-cypress') }}
+    if: ${{ !(contains(needs.prepare.outputs.commit-message, 'skip-cypress')) && !(github.actor == 'dependabot[bot]') }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,9 +254,9 @@ jobs:
           echo "TEST_PARAMS=-s 'tests/synpress/specs/${{ matrix.containers }}/*/*.ts'" >> "$GITHUB_ENV"
 
       - name: Check if pr is merged
-        if: ${{ (github.event_name == 'push') || (contains(needs.prepare.outputs.commit-message,'trigger-synpress-dashboard')) }}
+        if: ${{ (github.event_name == 'push') || (contains(needs.prepare.outputs.commit-message,'trigger-dashboard-synpress')) }}
         run: |
-          echo "TEST_PARAMS=-s 'tests/synpress/specs/${{ matrix.containers }}/*/*.ts --record --key=${{ secrets.CYPRESS_DASHBOARD_KEY }} --tag SYNPRESS --ci-build-id ${{ needs.prepare.outputs.uuid }}'" >> "$GITHUB_ENV"
+          echo "TEST_PARAMS=-s 'tests/synpress/specs/${{ matrix.containers }}/*/*.ts --record --key=${{ secrets.CYPRESS_DASHBOARD_KEY }} --ci-build-id ${{ needs.prepare.outputs.uuid }} --tag SYNPRESS'" >> "$GITHUB_ENV"
 
       - name: ⎔ Setup node
         uses: actions/setup-node@v3
@@ -341,7 +341,7 @@ jobs:
 
       - name: Run cypress tests after merge
         if: ${{ (github.event_name == 'push') }}
-        run: yarn cypress:ci './node_modules/.bin/cypress run -r mochawesome --record --group electron --key=${{ secrets.CYPRESS_DASHBOARD_KEY }} --parallel --tag SMOKE_TESTS --ci-build-id ${{ needs.prepare.outputs.uuid }}'
+        run: yarn cypress:ci './node_modules/.bin/cypress run -r mochawesome --record --group electron --key=${{ secrets.CYPRESS_DASHBOARD_KEY }} --parallel --ci-build-id ${{ needs.prepare.outputs.uuid }} --tag SMOKE_TESTS'
         continue-on-error: true
         env:
           COMMIT_INFO_MESSAGE: ${{github.event.pull_request.title}}

--- a/tests/cypress/integration/smoke/MenuBarTests.ts
+++ b/tests/cypress/integration/smoke/MenuBarTests.ts
@@ -4,6 +4,12 @@ import { SettingsDialog } from '../../../pages/SettingsDialog'
 
 describe('Menu bar smoke tests', () => {
   before(() => {
+    Cypress.on('uncaught:exception', err => {
+      // returning false here prevents Cypress from
+      // failing the test
+      console.log('Cypress detected uncaught exception: ', err)
+      return false
+    })
     cy.visit('/')
   })
   it('Should display nav items on every page [TC-16]', () => {
@@ -22,8 +28,8 @@ describe('Menu bar smoke tests', () => {
   it('Should redirect to correct page after clicking on nav item [TC-16]', () => {
     MenuBar.getRewards().click().url().should('include', 'rewards')
     MenuBar.getLiquidity().click().url().should('include', 'pools')
-    MenuBar.getBridge().click().url().should('include', 'bridge')
     MenuBar.getSwap().click().url().should('include', 'swap')
+    MenuBar.getBridge().click().url().should('include', 'bridge')
   })
   it('Should open network switcher with all networks [TC-17]', () => {
     MenuBar.getNetworkSwitcher().click()

--- a/tests/cypress/integration/smoke/MenuBarTests.ts
+++ b/tests/cypress/integration/smoke/MenuBarTests.ts
@@ -4,12 +4,6 @@ import { SettingsDialog } from '../../../pages/SettingsDialog'
 
 describe('Menu bar smoke tests', () => {
   before(() => {
-    Cypress.on('uncaught:exception', err => {
-      // returning false here prevents Cypress from
-      // failing the test
-      console.log('Cypress detected uncaught exception: ', err)
-      return false
-    })
     cy.visit('/')
   })
   it('Should display nav items on every page [TC-16]', () => {

--- a/tests/synpress/specs/02transactionfull/bridge/BridgeTests.ts
+++ b/tests/synpress/specs/02transactionfull/bridge/BridgeTests.ts
@@ -13,12 +13,6 @@ describe('Bridge tests', () => {
   const TRANSACTION_VALUE = 1
 
   before(() => {
-    Cypress.on('uncaught:exception', err => {
-      // returning false here prevents Cypress from
-      // failing the test
-      console.log('Cypress detected uncaught exception: ', err)
-      return false
-    })
     ScannerFacade.erc20TokenBalance(
       AddressesEnum.USDC_TOKEN_ARINKEBY,
       AddressesEnum.WALLET_PUBLIC,

--- a/tests/synpress/specs/02transactionfull/bridge/BridgeTests.ts
+++ b/tests/synpress/specs/02transactionfull/bridge/BridgeTests.ts
@@ -13,6 +13,12 @@ describe('Bridge tests', () => {
   const TRANSACTION_VALUE = 1
 
   before(() => {
+    Cypress.on('uncaught:exception', err => {
+      // returning false here prevents Cypress from
+      // failing the test
+      console.log('Cypress detected uncaught exception: ', err)
+      return false
+    })
     ScannerFacade.erc20TokenBalance(
       AddressesEnum.USDC_TOKEN_ARINKEBY,
       AddressesEnum.WALLET_PUBLIC,

--- a/tests/synpress/specs/02transactionfull/bridge/BridgeTests.ts
+++ b/tests/synpress/specs/02transactionfull/bridge/BridgeTests.ts
@@ -8,8 +8,7 @@ import { ChainsEnum } from '../../../../utils/enums/ChainsEnum'
 import { ErrorModal } from '../../../../pages/ErrorModal'
 import { MetamaskNetworkHandler } from '../../../../utils/MetamaskNetworkHandler'
 
-//TODO - unskip after #1379 is fixed
-describe.skip('Bridge tests', () => {
+describe('Bridge tests', () => {
   let balanceBefore: number
   const TRANSACTION_VALUE = 1
 


### PR DESCRIPTION
This PR contains few improvements to the tests parts of CI pipe. It checks commit messages if they contain any flag that may change the way of starting tests:

*skip-cypress* - to skip cypress smoke tests 
*trigger-synpress* - to trigger run of synpress e2e tests
*trigger-synpress-dashboard* - to trigger run of synpress e2e tests with cypress dashboard reporter

Example: *git commit --allow-empty -m "skip-cypress" && git push* will trigger CI run without running any test

Also after the merge of this pr rerun of CI pipe should not cause fail of whole pipe