### PR TITLE
feat: add Görli

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@reduxjs/toolkit": "^1.8.3",
     "@swapr/core": "^0.3.19",
     "@swapr/periphery": "^0.3.22",
-    "@swapr/sdk": "1.6.0-rc.3",
+    "@swapr/sdk": "1.6.0-rc.4",
     "@uniswap/token-lists": "^1.0.0-beta.27",
     "@web3-react/core": "^6.1.9",
     "@web3-react/injected-connector": "^6.0.7",

--- a/src/apollo/client.ts
+++ b/src/apollo/client.ts
@@ -10,6 +10,7 @@ export const subgraphClientsUris: { [chainId in SWPRSupportedChains]: string } =
   [ChainId.ARBITRUM_ONE]: 'https://api.thegraph.com/subgraphs/name/dxgraphs/swapr-arbitrum-one-v3',
   [ChainId.XDAI]: 'https://api.thegraph.com/subgraphs/name/dxgraphs/swapr-xdai-v2',
   [ChainId.RINKEBY]: 'https://api.thegraph.com/subgraphs/name/dxgraphs/swapr-rinkeby',
+  [ChainId.GOERLI]: 'https://api.thegraph.com/subgraphs/name/dxgraphs/swapr-goerli',
   [ChainId.ARBITRUM_RINKEBY]: 'https://api.thegraph.com/subgraphs/name/dxgraphs/swapr-arbitrum-rinkeby-v2',
   [ChainId.ARBITRUM_GOERLI]: '', // FIXME: fix this once the subgraph is deployed
 }
@@ -30,6 +31,7 @@ export const subgraphClients: {
   [ChainId.ARBITRUM_ONE]: setupApolloClient(ChainId.ARBITRUM_ONE),
   // testnets
   [ChainId.RINKEBY]: setupApolloClient(ChainId.RINKEBY),
+  [ChainId.GOERLI]: setupApolloClient(ChainId.GOERLI),
   [ChainId.ARBITRUM_RINKEBY]: setupApolloClient(ChainId.ARBITRUM_RINKEBY),
   [ChainId.ARBITRUM_GOERLI]: setupApolloClient(ChainId.ARBITRUM_GOERLI), // FIXME: fix this once the subgraph is deployed
 }
@@ -37,6 +39,7 @@ export const subgraphClients: {
 export const immediateSubgraphClients: { [chainId in SWPRSupportedChains]: GraphQLClient } = {
   [ChainId.MAINNET]: new GraphQLClient(subgraphClientsUris[ChainId.MAINNET]),
   [ChainId.RINKEBY]: new GraphQLClient(subgraphClientsUris[ChainId.RINKEBY]),
+  [ChainId.GOERLI]: new GraphQLClient(subgraphClientsUris[ChainId.GOERLI]),
   [ChainId.XDAI]: new GraphQLClient(subgraphClientsUris[ChainId.XDAI]),
   [ChainId.ARBITRUM_ONE]: new GraphQLClient(subgraphClientsUris[ChainId.ARBITRUM_ONE]),
   [ChainId.ARBITRUM_RINKEBY]: new GraphQLClient(subgraphClientsUris[ChainId.ARBITRUM_RINKEBY]),
@@ -65,6 +68,7 @@ export const subgraphBlocksClientsUris: { [chainId in SWPRSupportedChains]: stri
   [ChainId.GNOSIS]: 'https://api.thegraph.com/subgraphs/name/1hive/xdai-blocks',
   // testnests
   [ChainId.RINKEBY]: 'https://api.thegraph.com/subgraphs/name/blocklytics/ethereum-blocks',
+  [ChainId.GOERLI]: 'https://api.thegraph.com/subgraphs/name/blocklytics/ethereum-blocks',
   [ChainId.ARBITRUM_RINKEBY]: 'https://api.thegraph.com/subgraphs/name/dodoex/arbitrum-one-blocks',
   [ChainId.ARBITRUM_GOERLI]: '', // FIXME: fix this once the subgraph is deployed
 }
@@ -83,6 +87,7 @@ export const subgraphBlocksClients: {
   [ChainId.ARBITRUM_ONE]: setupBlocksApolloClient(ChainId.ARBITRUM_ONE),
   // testnets
   [ChainId.RINKEBY]: setupBlocksApolloClient(ChainId.RINKEBY),
+  [ChainId.GOERLI]: setupBlocksApolloClient(ChainId.GOERLI),
   [ChainId.ARBITRUM_RINKEBY]: setupBlocksApolloClient(ChainId.ARBITRUM_RINKEBY),
   [ChainId.ARBITRUM_GOERLI]: setupBlocksApolloClient(ChainId.ARBITRUM_GOERLI), // FIXME: fix this once the subgraph is deployed
 }

--- a/src/components/NetworkSwitcher/NetworkSwitcher.preset.ts
+++ b/src/components/NetworkSwitcher/NetworkSwitcher.preset.ts
@@ -36,6 +36,13 @@ export const networkOptionsPreset: NetworkOptionsPreset[] = [
     tag: NetworkSwitcherTags.TESTNETS,
   },
   {
+    chainId: ChainId.GOERLI,
+    name: 'Görli',
+    logoSrc: EthereumLogo,
+    color: '#443780',
+    tag: NetworkSwitcherTags.TESTNETS,
+  },
+  {
     chainId: ChainId.ARBITRUM_RINKEBY,
     name: 'A.\xa0Rinkeby',
     logoSrc: ArbitrumLogo,

--- a/src/components/Web3Status/AccountStatus.tsx
+++ b/src/components/Web3Status/AccountStatus.tsx
@@ -24,6 +24,7 @@ import { RowBetween } from '../Row'
 const ChainLogo: any = {
   [ChainId.MAINNET]: EthereumLogo,
   [ChainId.RINKEBY]: EthereumLogo,
+  [ChainId.GOERLI]: EthereumLogo,
   [ChainId.ARBITRUM_ONE]: ArbitrumLogo,
   [ChainId.ARBITRUM_RINKEBY]: ArbitrumLogo,
   [ChainId.XDAI]: GnosisLogo,

--- a/src/connectors/index.ts
+++ b/src/connectors/index.ts
@@ -31,6 +31,7 @@ export const injected = new InjectedConnector({
     ChainId.XDAI,
     ChainId.POLYGON,
     ChainId.ARBITRUM_GOERLI,
+    ChainId.GOERLI,
   ],
 })
 

--- a/src/constants/index.tsx
+++ b/src/constants/index.tsx
@@ -433,6 +433,17 @@ export const NETWORK_DETAIL: { [chainId: number]: NetworkDetails } = {
     rpcUrls: ['https://rinkeby.infura.io/v3'],
     blockExplorerUrls: ['https://rinkeby.etherscan.io'],
   },
+  [ChainId.GOERLI]: {
+    chainId: `0x${ChainId.GOERLI.toString(16)}`,
+    chainName: 'Görli',
+    nativeCurrency: {
+      name: Currency.ETHER.name || 'Ether',
+      symbol: Currency.ETHER.symbol || 'ETH',
+      decimals: Currency.ETHER.decimals || 18,
+    },
+    rpcUrls: ['https://goerli.infura.io/v3'],
+    blockExplorerUrls: ['https://goerli.etherscan.io'],
+  },
   [ChainId.POLYGON]: {
     chainId: `0x${ChainId.POLYGON.toString(16)}`,
     chainName: 'Polygon Mainnet',

--- a/src/utils/chainSupportsSWPR.ts
+++ b/src/utils/chainSupportsSWPR.ts
@@ -1,11 +1,7 @@
 import { ChainId, SWPR } from '@swapr/sdk'
 
 // Includes chains on which swpr has its infrastructure
-export type SWPRUnsupportedChains =
-  | ChainId.POLYGON
-  | ChainId.OPTIMISM_MAINNET
-  | ChainId.OPTIMISM_GOERLI
-  | ChainId.GOERLI
+export type SWPRUnsupportedChains = ChainId.POLYGON | ChainId.OPTIMISM_MAINNET | ChainId.OPTIMISM_GOERLI
 export type SWPRSupportedChains = Exclude<ChainId, SWPRUnsupportedChains>
 
 export const chainSupportsSWPR = (chainId?: ChainId) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5284,6 +5284,13 @@
   dependencies:
     typescript "^3.9.5"
 
+"@swapr/core@^0.3.20":
+  version "0.3.20"
+  resolved "https://registry.yarnpkg.com/@swapr/core/-/core-0.3.20.tgz#2ba381565b09298a1c298fbf3939788783a2fa83"
+  integrity sha512-wUBRsb+Oahm4HUHBP1Ou/X3wY+6gLKjj0Zz6+G5nqDmtkpQhYSGRQvmtNZXbVKFtQAsNlLo2mGNF1T1haMOWSQ==
+  dependencies:
+    typescript "^3.9.5"
+
 "@swapr/periphery@^0.3.22":
   version "0.3.22"
   resolved "https://registry.yarnpkg.com/@swapr/periphery/-/periphery-0.3.22.tgz#d1c084e9cb186c44e24ee0757843d595e315de95"
@@ -5291,10 +5298,17 @@
   dependencies:
     "@swapr/core" "^0.3.17"
 
-"@swapr/sdk@1.6.0-rc.3":
-  version "1.6.0-rc.3"
-  resolved "https://registry.yarnpkg.com/@swapr/sdk/-/sdk-1.6.0-rc.3.tgz#af840743e04abfc79533cafbfe91379f7b44a2af"
-  integrity sha512-Lq2lIoxOWoUoDffurAZZtVVvE2TFpctuAYMgMBVl5LPF+DN0ckrBga5BLa53en2HzsE1dON5ZHEu6SfbU6LqcA==
+"@swapr/periphery@^0.3.23":
+  version "0.3.23"
+  resolved "https://registry.yarnpkg.com/@swapr/periphery/-/periphery-0.3.23.tgz#250090655cf9f02a485890763334e5101c0b3a4f"
+  integrity sha512-6ihqkdWkiEaVJ+hM4vBreoMA9er6RM+iD8T54tOfCvcR50aWbgRlfxTzFY6iZjR3IwAqph3ww/+QcJXv+mLemw==
+  dependencies:
+    "@swapr/core" "^0.3.17"
+
+"@swapr/sdk@1.6.0-rc.4":
+  version "1.6.0-rc.4"
+  resolved "https://registry.yarnpkg.com/@swapr/sdk/-/sdk-1.6.0-rc.4.tgz#e3f502f1db4bc5866d6211e9eb01ef12326a2df6"
+  integrity sha512-spBuAxqh7cVl+hF4g16l5dkML0yi5LV2qGNGzysb9tNCa1gp9QBCeSyG4Tpl7ey7lLYyZeIDPrQt+13uNsMpXw==
   dependencies:
     "@cowprotocol/cow-sdk" "^0.0.15"
     "@ethersproject/abi" "^5.6.4"
@@ -5307,9 +5321,9 @@
     "@ethersproject/solidity" "^5.4.0"
     "@ethersproject/transactions" "^5.4.0"
     "@ethersproject/units" "^5.4.0"
-    "@swapr/core" "^0.3.19"
-    "@swapr/periphery" "^0.3.22"
-    "@uniswap/smart-order-router" "^2.6.0"
+    "@swapr/core" "^0.3.20"
+    "@swapr/periphery" "^0.3.23"
+    "@uniswap/smart-order-router" "^2.8.2"
     big.js "^5.2.2"
     dayjs "^1.11.0"
     debug "^4.3.4"
@@ -6510,7 +6524,7 @@
     tiny-invariant "^1.1.0"
     toformat "^2.0.0"
 
-"@uniswap/smart-order-router@2.5.26", "@uniswap/smart-order-router@^2.6.0":
+"@uniswap/smart-order-router@2.5.26", "@uniswap/smart-order-router@^2.8.2":
   version "2.5.26"
   resolved "https://registry.yarnpkg.com/@uniswap/smart-order-router/-/smart-order-router-2.5.26.tgz#8954cd1bca476bf821aaffe81071bcf89bc869b8"
   integrity sha512-KCjxZoPawBEkvt5pJutsPC1Db61f6qrnSpWUPeC8fRJEKXc72msbtzopqB4q4ex5S0Ax3ck4gbA1qRO7zBeixQ==


### PR DESCRIPTION
# Summary

Adds support for Görli testnet and Swapr platform on the network. This config does not add support for DIY farming. We haven't deployed the staking contracts to Görli just yet. 

# To Test

- User should be able to: 
   - View and manage liquidity pairs.
   - Retrieve data from the subgraph.
   - Wrap ETH to WETH and trade using Swapr.
- Görli config does not break the dapp on the Bridge page.
