### PR TITLE
feature(connext-bridge): suppress logs from sdk

### DIFF
--- a/src/services/EcoBridge/Connext/Connext.ts
+++ b/src/services/EcoBridge/Connext/Connext.ts
@@ -35,7 +35,7 @@ import {
   ConnextTransactionsSubgraph,
   ConnextTransactionStatus,
 } from './Connext.types'
-import { getReceivingTransaction, getTransactionsQuery, QUERY_NATIVE_PRICE } from './Connext.utils'
+import { getReceivingTransaction, getTransactionsQuery, QUERY_NATIVE_PRICE, SilentLogger } from './Connext.utils'
 
 export class Connext extends EcoBridgeChildBase {
   private _connextSdk: NxtpSdk | undefined
@@ -86,11 +86,13 @@ export class Connext extends EcoBridgeChildBase {
   }
 
   private _createConnextSdk = async (signer: Signer) => {
+    const silentLogger = new SilentLogger()
     try {
       const connextSdk = await NxtpSdk.create({
         chainConfig: connextSdkChainConfig,
         signer,
         skipPolling: false,
+        logger: silentLogger,
       })
 
       if (connextSdk) {

--- a/src/services/EcoBridge/Connext/Connext.utils.ts
+++ b/src/services/EcoBridge/Connext/Connext.utils.ts
@@ -1,4 +1,21 @@
+import { Logger } from '@connext/nxtp-utils'
 import { gql } from 'graphql-request'
+
+/**
+ * Used to suppress logs from connext sdk
+ */
+export class SilentLogger extends Logger {
+  constructor(...args: any[]) {
+    super(args)
+    this['print'] = () => {
+      return
+    }
+
+    this.child = (...any: any[]) => {
+      return new SilentLogger(...any)
+    }
+  }
+}
 
 export const QUERY_NATIVE_PRICE = gql`
   query {


### PR DESCRIPTION
# Summary
This PR introduces SilentLogger class that suppresses `print` method of default Logger used in connext sdk. Thanks to it browser's console is not spammed by undesired logs anymore. 

# Background
While working on different task I've noticed that console is spammed by logs from unknown origin: 

![image](https://user-images.githubusercontent.com/110498499/188286903-3a638973-bacb-4636-a2a7-d9515ccdf556.png)

After brief investigation I found out that they were made by connext-sdk. There is no way to disable these logs in sdk config so I wrote implementation that suppresses `print` method in Logger and it's children instances. All other logs like errors and warnings will work as expected.

If you find these logs useful please disregard & close this PR. 