### PR TITLE
Doesn't show routes when input is not selected

### DIFF
--- a/src/state/swap/hooks.ts
+++ b/src/state/swap/hooks.ts
@@ -315,7 +315,7 @@ export function useDerivedSwapInfo(platformOverride?: RoutablePlatform): UseDeri
     },
     parsedAmount,
     trade,
-    allPlatformTrades,
+    allPlatformTrades: inputError === SWAP_INPUT_ERRORS.SELECT_TOKEN ? [] : allPlatformTrades,
     inputError: returnInputError,
     loading,
   }


### PR DESCRIPTION
- This is a quick fix but the issue is with the asynchronous function inside the useEffect hook called getTrades Im not sure yet how to approach it but we need refactor of this useDerivedSwapInfo hook. I think we should start off by moving the async function out of the useEffect and making a hook just for it.
closes #1350 