### PR TITLE
Change to swap if current page is unavailable in current chain

### DIFF
--- a/src/connectors/CustomNetworkConnector.ts
+++ b/src/connectors/CustomNetworkConnector.ts
@@ -126,12 +126,13 @@ export class CustomNetworkConnector extends AbstractConnector {
   public changeChainId(chainId: number) {
     invariant(Object.keys(this.providers).includes(chainId.toString()), `No url found for chainId ${chainId}`)
     this.currentChainId = chainId
-    this.emitUpdate({ provider: this.providers[this.currentChainId], chainId })
+    return new Promise(() => this.emitUpdate({ provider: this.providers[this.currentChainId], chainId }))
   }
 
   public switchUnsupportedNetwork(networkDetails?: NetworkDetails) {
-    if (!window.ethereum || !window.ethereum.request || !window.ethereum.isMetaMask || !networkDetails) return
-    window.ethereum
+    if (!window.ethereum || !window.ethereum.request || !window.ethereum.isMetaMask || !networkDetails)
+      return new Promise(() => {})
+    return window.ethereum
       .request({
         method: 'wallet_switchEthereumChain',
         params: [{ chainId: networkDetails.chainId }],

--- a/src/connectors/CustomWalletLinkConnector.ts
+++ b/src/connectors/CustomWalletLinkConnector.ts
@@ -88,7 +88,7 @@ export class CustomWalletLinkConnector extends AbstractConnector {
   }
 
   public changeChainId(networkDetails: NetworkDetails, account?: string | undefined) {
-    this.provider
+    return this.provider
       .request({
         method: 'wallet_switchEthereumChain',
         params: [{ chainId: networkDetails.chainId }],

--- a/src/hooks/useNetworkSwitch.ts
+++ b/src/hooks/useNetworkSwitch.ts
@@ -34,7 +34,12 @@ export const useNetworkSwitch = ({ onSelectNetworkCallback }: UseNetworkSwitchPr
 
       if (onSelectNetworkCallback) onSelectNetworkCallback()
       changeChainId.then(() => {
-        if (!SWPR[optionChainId]) window.location.replace('../swap')
+        if (
+          !SWPR[optionChainId] &&
+          // check if the URL includes any of these
+          ['/pools', '/rewards'].reduce((state, str) => state || window.location.href.includes(str), false)
+        )
+          window.location.replace('../swap')
       })
     },
     [account, chainId, connector, onSelectNetworkCallback, unsupportedChainIdError]

--- a/src/hooks/useNetworkSwitch.ts
+++ b/src/hooks/useNetworkSwitch.ts
@@ -1,4 +1,4 @@
-import { ChainId } from '@swapr/sdk'
+import { ChainId, SWPR } from '@swapr/sdk'
 
 import { InjectedConnector } from '@web3-react/injected-connector'
 import { useCallback } from 'react'
@@ -6,6 +6,7 @@ import { useCallback } from 'react'
 import { CustomNetworkConnector } from '../connectors/CustomNetworkConnector'
 import { CustomWalletLinkConnector } from '../connectors/CustomWalletLinkConnector'
 import { NETWORK_DETAIL } from '../constants'
+// import { RedirectToSwap } from '../pages/Swap/redirects'
 import { switchOrAddNetwork } from '../utils'
 
 import { useActiveWeb3React, useUnsupportedChainIdError } from '.'
@@ -21,16 +22,20 @@ export const useNetworkSwitch = ({ onSelectNetworkCallback }: UseNetworkSwitchPr
   const selectNetwork = useCallback(
     (optionChainId?: ChainId) => {
       if (optionChainId === undefined || (optionChainId === chainId && !unsupportedChainIdError)) return
+      let changeChainId = new Promise(() => {})
       if (!account && !unsupportedChainIdError && connector instanceof CustomNetworkConnector)
-        connector.changeChainId(optionChainId)
+        changeChainId = connector.changeChainId(optionChainId)
       else if (!account && unsupportedChainIdError && connector instanceof CustomNetworkConnector)
-        connector.switchUnsupportedNetwork(NETWORK_DETAIL[optionChainId])
+        changeChainId = connector.switchUnsupportedNetwork(NETWORK_DETAIL[optionChainId])
       else if (connector instanceof InjectedConnector)
-        switchOrAddNetwork(NETWORK_DETAIL[optionChainId], account || undefined)
+        changeChainId = switchOrAddNetwork(NETWORK_DETAIL[optionChainId], account || undefined)
       else if (connector instanceof CustomWalletLinkConnector)
-        connector.changeChainId(NETWORK_DETAIL[optionChainId], account || undefined)
+        changeChainId = connector.changeChainId(NETWORK_DETAIL[optionChainId], account || undefined)
 
       if (onSelectNetworkCallback) onSelectNetworkCallback()
+      changeChainId.then(() => {
+        if (!SWPR[optionChainId]) window.location.replace('../swap')
+      })
     },
     [account, chainId, connector, onSelectNetworkCallback, unsupportedChainIdError]
   )

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -217,8 +217,9 @@ export const calculatePercentage = (value: number, percentage: number): number =
 }
 
 export const switchOrAddNetwork = (networkDetails?: NetworkDetails, account?: string) => {
-  if (!window.ethereum || !window.ethereum.request || !window.ethereum.isMetaMask || !networkDetails || !account) return
-  window.ethereum
+  if (!window.ethereum || !window.ethereum.request || !window.ethereum.isMetaMask || !networkDetails || !account)
+    return new Promise(() => {})
+  return window.ethereum
     .request({
       method: 'wallet_switchEthereumChain',
       params: [{ chainId: networkDetails.chainId }],


### PR DESCRIPTION
# Summary

<<if there's an issue>>Fixes #1431

Some chains don't have Liquidity and Rewards available.
This fix checks if these pages are available and, if not, redirects to swap.

You **should not** be redirected if changing to a chain that supports these pages.
You **should not** be redirected if you are on swap or on the bridge.

  # To Test

1. Select a chain with these pages available. Example: Mainnet
2. Select Rewards or Liquidity page.
3. Change to a network that does not support these pages. Examples: Polygon, Optimism
4. Confirm the network change on the wallet popup. You should be redirected to swap.
