### PR TITLE
bugfix: remove static provider in eco router

### DIFF
--- a/src/state/swap/hooks.ts
+++ b/src/state/swap/hooks.ts
@@ -237,19 +237,13 @@ export function useDerivedSwapInfo(platformOverride?: RoutablePlatform): UseDeri
         useMultihops,
       },
     }
-
-    // Use a static version
-    const staticProvider = provider ? new StaticJsonRpcProvider(provider.connection, provider.network) : undefined
-
-    console.log('useDerivedSwapInfo: fetching trades')
-
     const getTrades = getTradesPromise(
       parsedAmount,
       inputCurrency,
       outputCurrency,
       commonParams,
       ecoRouterSourceOptionsParams,
-      staticProvider
+      provider
     )
 
     // Start fetching trades from EcoRouter API


### PR DESCRIPTION
# Summary

~~Adds `http` protocol to `StaticJsonRpcProvider` instance.~~ Removes static provider condition. 