### PR TITLE
Added check if pr got 'ready-for-tests' label to save test results capacity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,8 @@ jobs:
       - name: Echo commit message
         run: echo "${{ steps.commit-message.outputs.value }}"
 
-      - uses: luisrjaeger/approved-event-checker@v1.0.0
+      - name: approved-event-checker
+        uses: luisrjaeger/approved-event-checker@1.0.0
         id: approved
         with:
           approvals: 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,13 +41,13 @@ jobs:
       - name: Echo commit message
         run: echo "${{ steps.commit-message.outputs.value }}"
 
-      - name: approved-event-checker
-        uses: taichi/approved-event-action@v1.2.1
+      - name: multi-approved-event
+      - uses: sakhnovict/multi-approved-event-action@1.0.9
         id: approved
         with:
-          approvals: 1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          approvalsCount: '2'
+          onlyEqual: 'false'
+
       - run: echo "Approved !!"
         if: ${{ steps.approved.outputs.approved == 'true' }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -370,7 +370,7 @@ jobs:
 
       - name: Run cypress tests
         if: ${{ !(github.event_name == 'push') }}
-        run: yarn cypress:ci './node_modules/.bin/cypress run -r mochawesome --record --group electron --key=${{ secrets.CYPRESS_DASHBOARD_KEY }} --parallel --tag TESTS_FROM_PR --ci-build-id=${{ ${{ needs.prepare.outputs.uuid }}'
+        run: yarn cypress:ci './node_modules/.bin/cypress run -r mochawesome --record --group electron --key=${{ secrets.CYPRESS_DASHBOARD_KEY }} --parallel --tag TESTS_FROM_PR --ci-build-id=${{ needs.prepare.outputs.uuid }}'
         continue-on-error: true
         env:
           COMMIT_INFO_MESSAGE: ${{github.event.pull_request.title}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,15 @@ concurrency:
 
 jobs:
   prepare:
+    name: Check how tests should be executed
     runs-on: ubuntu-20.04
     outputs:
       uuid: ${{ steps.uuid.outputs.value }}
       commit-message: ${{ steps.commit-message.outputs.value }}
+      is-label-present: ${{ steps.label-present.outputs.value }}
+      cypress: ${{ steps.cypress.outputs.value }}
+      synpress: ${{ steps.synpress.outputs.value }}
+
     steps:
       - name: ⬇️ ・Checkout repo
         uses: actions/checkout@v3
@@ -41,28 +46,33 @@ jobs:
       - name: Echo commit message
         run: echo "${{ steps.commit-message.outputs.value }}"
 
-  check-if-tests-should-run:
-    runs-on: ubuntu-20.04
-    outputs:
-      is-label-present: ${{ steps.label-present.outputs.value }}
+      - uses: docker://agilepathway/pull-request-label-checker:latest
+        id: check-if-tests-should-run
+        continue-on-error: true
+        with:
+          one_of: ready-for-tests
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
 
-    steps:
-    - uses: docker://agilepathway/pull-request-label-checker:latest
-      id: check-if-tests-should-run
-      continue-on-error: true
-      with:
-        one_of: ready-for-tests
-        repo_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Check if label is present
+        if: steps.check-if-tests-should-run.outcome == 'success'
+        id: label-present
+        run: |
+          echo "Label present"
+          echo "::set-output name=value::true"
 
+      - name: Check if cypress tests should be executed
+        id: cypress
+        if: ${{ ((github.event_name == 'push') || ((steps.label-present.outputs.value == 'true')&& !(github.actor == 'dependabot[bot]'))) }}
+        run: |
+          echo "Cypress tests should be executed"
+          echo "::set-output name=value::true"
 
-
-    - name: Create comment if build is ok
-      if: steps.check-if-tests-should-run.outcome == 'success'
-      id: label-present
-      run: |
-        echo "Label present"
-        echo "::set-output name=value::true"
-
+      - name: Check if synpress tests should be executed
+        id: synpress
+        if: ${{ (steps.label-present.outputs.value == 'true' || github.event_name == 'push') }}
+        run: |
+          echo "Synpress tests should be executed"
+          echo "::set-output name=value::true"
 
   install:
     name: Install
@@ -249,7 +259,7 @@ jobs:
     runs-on: ubuntu-20.04
     needs: [prepare]
     container: cypress/base:16.5.0
-    if: ${{ (contains(needs.prepare.outputs.commit-message, 'trigger-synpress') || github.event_name == 'push') }}
+    if:
     env:
       PRIVATE_KEY: ${{ secrets.TEST_WALLET_PRIVATE_KEY }}
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Check if synpress tests should be executed
         id: synpress
-        if: ${{ (steps.label-present.outputs.value == 'true' || github.event_name == 'push') }}
+        if: ${{ contains(needs.prepare.outputs.commit-message,'trigger-synpress' || github.event_name == 'push') }}
         run: |
           echo "Synpress tests should be executed"
           echo "::set-output name=value::true"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -340,7 +340,7 @@ jobs:
     needs: [install, prepare]
     runs-on: ubuntu-20.04
     container: swapr/cypress:zstd
-    if: ${{ ((github.event_name == 'push') ||((needs.check-if-tests-should-run.outputs.uuid steps.check-if-tests-should-run.outcome == 'success')&& !(github.actor == 'dependabot[bot]')) }}
+    if: ${{ ((github.event_name == 'push') ||((needs.check-if-tests-should-run.outputs.uuid == 'true')&& !(github.actor == 'dependabot[bot]')) }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,7 @@ jobs:
         with:
           approvalsCount: '2'
           onlyEqual: 'false'
+        env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
       - run: echo "Approved !!"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,29 +56,43 @@ jobs:
         run: echo "${{ steps.commit-message.outputs.value }}"
 
       - uses: docker://agilepathway/pull-request-label-checker:latest
-        id: check-if-tests-should-run
+        id: check-if-cypress-tests-should-run
         continue-on-error: true
         with:
           one_of: ready-for-tests, QA
           repo_token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Check if label is present
-        if: steps.check-if-tests-should-run.outcome == 'success'
-        id: label-present
+      - uses: docker://agilepathway/pull-request-label-checker:latest
+        id: check-if-synpress-tests-should-run
+        continue-on-error: true
+        with:
+          one_of: ready-for-synpress-tests, QA
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check if cypress label is present
+        if: steps.check-if-cypress-tests-should-run.outcome == 'success'
+        id: cypress-label-present
+        run: |
+          echo "Label present"
+          echo "::set-output name=value::true"
+
+      - name: Check if synpress label is present
+        if: steps.check-if-synpress-tests-should-run.outcome == 'success'
+        id: synpress-label-present
         run: |
           echo "Label present"
           echo "::set-output name=value::true"
 
       - name: Check if cypress tests should be executed
         id: cypress
-        if: ${{ ((github.event_name == 'push') || ((steps.label-present.outputs.value == 'true')&& !(github.actor == 'dependabot[bot]'))) }}
+        if: ${{ ((github.event_name == 'push') || ((steps.cypress-label-present.outputs.value == 'true')&& !(github.actor == 'dependabot[bot]'))) }}
         run: |
           echo "Cypress tests should be executed"
           echo "::set-output name=value::true"
 
       - name: Check if synpress tests should be executed
         id: synpress
-        if: ${{ contains(steps.commit-message.outputs.value,'trigger-synpress' || github.event_name == 'push') }}
+        if: ${{ contains(steps.commit-message.outputs.value,'trigger-synpress') || github.event_name == 'push' || (steps.synpress-label-present.outputs.value == 'true') }}
         run: |
           echo "Synpress tests should be executed"
           echo "::set-output name=value::true"
@@ -291,7 +305,7 @@ jobs:
           echo "TEST_PARAMS=-s 'tests/synpress/specs/${{ matrix.containers }}/*/*.ts'" >> "$GITHUB_ENV"
 
       - name: Check if synpress should be reported to dashboard
-        if: ${{ (github.event_name == 'push') || (contains(needs.prepare.outputs.commit-message,'trigger-synpress-dashboard')) }}
+        if: ${{ (github.event_name == 'push') || !(contains(needs.prepare.outputs.commit-message,'skip-synpress-dashboard')) }}
         run: |
           echo "TEST_PARAMS=-s 'tests/synpress/specs/${{ matrix.containers }}/*/*.ts --record --key=${{ secrets.CYPRESS_DASHBOARD_KEY }} --tag SYNPRESS'" >> "$GITHUB_ENV"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,7 @@ jobs:
         with:
           approvalsCount: '2'
           onlyEqual: 'false'
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
       - run: echo "Approved !!"
         if: ${{ steps.approved.outputs.approved == 'true' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,7 @@ jobs:
         run: |
           MSG=$(git log --format=%B -n 1 ${{github.event.after}})
           echo "::set-output name=value::$(printf "$MSG" | xargs)"
+
       - name: Echo commit message
         run: echo "${{ steps.commit-message.outputs.value }}"
 
@@ -77,7 +78,7 @@ jobs:
 
       - name: Check if synpress tests should be executed
         id: synpress
-        if: ${{ contains(needs.prepare.outputs.commit-message,'trigger-synpress' || github.event_name == 'push') }}
+        if: ${{ contains(steps.commit-message.outputs.value,'trigger-synpress' || github.event_name == 'push') }}
         run: |
           echo "Synpress tests should be executed"
           echo "::set-output name=value::true"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,13 +41,12 @@ jobs:
       - name: Echo commit message
         run: echo "${{ steps.commit-message.outputs.value }}"
 
-      - uses: snow-actions/unanimously-approved@v2.0.0
-        id: unanimously-approved
-      - run: echo "Approved !!"
-        if: ${{ steps.approved.outputs.approved == 'true' }}
-
-      - run: echo "Disapproved !!"
-        if: ${{ steps.approved.outputs.approved == 'false' }}
+      - uses: taichi/approved-event-action@v1.2.1
+        id: approved
+        with:
+          approvals: '2'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   install:
     name: Install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -340,7 +340,7 @@ jobs:
     needs: [install, prepare]
     runs-on: ubuntu-20.04
     container: swapr/cypress:zstd
-    if: ${{ ((github.event_name == 'push') ||((needs.check-if-tests-should-run.outputs.uuid == 'true')&& !(github.actor == 'dependabot[bot]')) }}
+    if: ${{ ((github.event_name == 'push') ||((needs.check-if-tests-should-run.outputs.uuid == 'true')&& !(github.actor == 'dependabot[bot]'))) }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,15 +41,8 @@ jobs:
       - name: Echo commit message
         run: echo "${{ steps.commit-message.outputs.value }}"
 
-      - name: multi-approved-event
-        uses: sakhnovict/multi-approved-event-action@1.0.9
-        id: approved
-        with:
-          approvalsCount: '2'
-          onlyEqual: 'false'
-        env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-
+      - uses: snow-actions/unanimously-approved@v2.0.0
+        id: unanimously-approved
       - run: echo "Approved !!"
         if: ${{ steps.approved.outputs.approved == 'true' }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -370,7 +370,7 @@ jobs:
 
       - name: Run cypress tests
         if: ${{ !(github.event_name == 'push') }}
-        run: yarn cypress:ci './node_modules/.bin/cypress run -r mochawesome --record --group electron --key=${{ secrets.CYPRESS_DASHBOARD_KEY }} --parallel --tag TESTS_FROM_PR'
+        run: yarn cypress:ci './node_modules/.bin/cypress run -r mochawesome --record --group electron --key=${{ secrets.CYPRESS_DASHBOARD_KEY }} --parallel --tag TESTS_FROM_PR --ci-build-id=${{ ${{ needs.prepare.outputs.uuid }}'
         continue-on-error: true
         env:
           COMMIT_INFO_MESSAGE: ${{github.event.pull_request.title}}
@@ -378,7 +378,7 @@ jobs:
 
       - name: Run cypress tests after merge
         if: ${{ (github.event_name == 'push') }}
-        run: yarn cypress:ci './node_modules/.bin/cypress run -r mochawesome --record --group electron --key=${{ secrets.CYPRESS_DASHBOARD_KEY }} --parallel }} --tag SMOKE_TESTS'
+        run: yarn cypress:ci './node_modules/.bin/cypress run -r mochawesome --record --group electron --key=${{ secrets.CYPRESS_DASHBOARD_KEY }} --parallel }} --tag SMOKE_TESTS --ci-build-id=${{ ${{ needs.prepare.outputs.uuid }}'
         continue-on-error: true
         env:
           COMMIT_INFO_MESSAGE: ${{github.event.pull_request.title}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,8 +44,7 @@ jobs:
   check-if-tests-should-run:
     runs-on: ubuntu-20.04
     outputs:
-      uuid: ${{ steps.uuid.outputs.value }}
-      commit-message: ${{ steps.commit-message.outputs.value }}
+      is-label-present: ${{ steps.label-present.outputs.value }}
     steps:
     - uses: docker://agilepathway/pull-request-label-checker:latest
       id: check-if-tests-should-run
@@ -341,7 +340,7 @@ jobs:
     needs: [install, prepare]
     runs-on: ubuntu-20.04
     container: swapr/cypress:zstd
-    if: ${{ ((github.event_name == 'push') ||((steps.check-if-tests-should-run.outcome == 'success')&& !(github.actor == 'dependabot[bot]')) }}
+    if: ${{ ((github.event_name == 'push') ||((needs.check-if-tests-should-run.outputs.uuid steps.check-if-tests-should-run.outcome == 'success')&& !(github.actor == 'dependabot[bot]')) }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Check if cypress tests should be executed
         id: cypress
-        if: ${{ ((github.event_name == 'push') || ((steps.label-present.outputs.value == 'true')&& !(github.actor == 'dependabot[bot]') && !(contains(steps.commit-message.outputs.value,'skip-cypress'))) }}
+        if: ${{ ((github.event_name == 'push') || ((steps.label-present.outputs.value == 'true')&& !(github.actor == 'dependabot[bot]') && !(contains(steps.commit-message.outputs.value,'skip-cypress')))) }}
         run: |
           echo "Cypress tests should be executed"
           echo "::set-output name=value::true"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
         run: echo "${{ steps.commit-message.outputs.value }}"
 
       - name: multi-approved-event
-      - uses: sakhnovict/multi-approved-event-action@1.0.9
+        uses: sakhnovict/multi-approved-event-action@1.0.9
         id: approved
         with:
           approvalsCount: '2'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Check if cypress tests should be executed
         id: cypress
-        if: ${{ ((github.event_name == 'push') || ((steps.label-present.outputs.value == 'true')&& !(github.actor == 'dependabot[bot]') && !(contains(steps.commit-message.outputs.value,'skip-cypress')))) }}
+        if: ${{ ((github.event_name == 'push') || ((steps.label-present.outputs.value == 'true')&& !(github.actor == 'dependabot[bot]'))) }}
         run: |
           echo "Cypress tests should be executed"
           echo "::set-output name=value::true"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,10 +41,14 @@ jobs:
       - name: Echo commit message
         run: echo "${{ steps.commit-message.outputs.value }}"
 
-      - uses: docker://agilepathway/pull-request-label-checker:latest
-        with:
-          one_of: major,minor,patch
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
+  check-if-tests-should-run:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: docker://agilepathway/pull-request-label-checker:latest
+      id: check-if-tests-should-run
+      with:
+        one_of: ready-for-tests
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
 
   install:
     name: Install
@@ -319,7 +323,7 @@ jobs:
     needs: [install, prepare]
     runs-on: ubuntu-20.04
     container: swapr/cypress:zstd
-    if: ${{ !(contains(needs.prepare.outputs.commit-message, 'skip-cypress')) && !(github.actor == 'dependabot[bot]') }}
+    if: ${{ ((github.event_name == 'push') }}) ||((steps.check-if-tests-should-run.outcome == 'success')&& !(github.actor == 'dependabot[bot]')) }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -378,7 +378,7 @@ jobs:
 
       - name: Run cypress tests after merge
         if: ${{ (github.event_name == 'push') }}
-        run: yarn cypress:ci './node_modules/.bin/cypress run -r mochawesome --record --group electron --key=${{ secrets.CYPRESS_DASHBOARD_KEY }} --parallel }} --tag SMOKE_TESTS --ci-build-id=${{ ${{ needs.prepare.outputs.uuid }}'
+        run: yarn cypress:ci './node_modules/.bin/cypress run -r mochawesome --record --group electron --key=${{ secrets.CYPRESS_DASHBOARD_KEY }} --parallel }} --tag SMOKE_TESTS --ci-build-id=${{ needs.prepare.outputs.uuid }}'
         continue-on-error: true
         env:
           COMMIT_INFO_MESSAGE: ${{github.event.pull_request.title}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,12 +43,30 @@ jobs:
 
   check-if-tests-should-run:
     runs-on: ubuntu-20.04
+    outputs:
+      uuid: ${{ steps.uuid.outputs.value }}
+      commit-message: ${{ steps.commit-message.outputs.value }}
     steps:
     - uses: docker://agilepathway/pull-request-label-checker:latest
       id: check-if-tests-should-run
       with:
         one_of: ready-for-tests
         repo_token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Create comment if build is ok
+      if: ${{ success() }}
+      id: label-present
+      run: |
+        echo "Label present"
+        echo "::set-output name=value::true"
+
+    - name: Create comment if build is ok
+      if: ${{ failure() }}
+      id: label-present
+      run: |
+        echo "Label not present"
+        echo "::set-output name=value::false"
+
 
   install:
     name: Install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,12 +45,16 @@ jobs:
     runs-on: ubuntu-20.04
     outputs:
       is-label-present: ${{ steps.label-present.outputs.value }}
+
     steps:
     - uses: docker://agilepathway/pull-request-label-checker:latest
       id: check-if-tests-should-run
+      continue-on-error: true
       with:
         one_of: ready-for-tests
         repo_token: ${{ secrets.GITHUB_TOKEN }}
+
+
 
     - name: Create comment if build is ok
       if: ${{ success() }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,13 +59,6 @@ jobs:
         echo "Label present"
         echo "::set-output name=value::true"
 
-    - name: Create comment if build is ok
-      if: ${{ failure() }}
-      id: label-present
-      run: |
-        echo "Label not present"
-        echo "::set-output name=value::false"
-
 
   install:
     name: Install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
 
 
     - name: Create comment if build is ok
-      if: ${{ success() }}
+      if: steps.check-if-tests-should-run.outcome == 'success'
       id: label-present
       run: |
         echo "Label present"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -347,7 +347,7 @@ jobs:
     needs: [install, prepare]
     runs-on: ubuntu-20.04
     container: swapr/cypress:zstd
-    if: ${{ ((github.event_name == 'push') ||((needs.check-if-tests-should-run.outputs.uuid == 'true')&& !(github.actor == 'dependabot[bot]'))) }}
+    if: ${{ needs.prepare.outputs.cypress }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,11 +41,10 @@ jobs:
       - name: Echo commit message
         run: echo "${{ steps.commit-message.outputs.value }}"
 
-      - name: Dump GitHub context
-        env:
-          GITHUB_CONTEXT: ${{ toJSON(github) }}
-        run: echo "$GITHUB_CONTEXT"
-      - run: echo ${{ github.event.review.state }}
+      - uses: docker://agilepathway/pull-request-label-checker:latest
+        with:
+          one_of: major,minor,patch
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
 
   install:
     name: Install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,18 @@ jobs:
           echo "::set-output name=value::$(printf "$MSG" | xargs)"
       - name: Echo commit message
         run: echo "${{ steps.commit-message.outputs.value }}"
-  
+
+      - uses: luisrjaeger/approved-event-checker@v1.0.0
+        id: approved
+        with:
+          approvals: 1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - run: echo "Approved !!"
+        if: ${{ steps.approved.outputs.approved == 'true' }}
+
+      - run: echo "Disapproved !!"
+        if: ${{ steps.approved.outputs.approved == 'false' }}
 
   install:
     name: Install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -323,7 +323,7 @@ jobs:
     needs: [install, prepare]
     runs-on: ubuntu-20.04
     container: swapr/cypress:zstd
-    if: ${{ ((github.event_name == 'push') }}) ||((steps.check-if-tests-should-run.outcome == 'success')&& !(github.actor == 'dependabot[bot]')) }}
+    if: ${{ ((github.event_name == 'push') ||((steps.check-if-tests-should-run.outcome == 'success')&& !(github.actor == 'dependabot[bot]')) }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,7 +259,7 @@ jobs:
     runs-on: ubuntu-20.04
     needs: [prepare]
     container: cypress/base:16.5.0
-    if:
+    if: ${{ needs.prepare.outputs.synpress }}
     env:
       PRIVATE_KEY: ${{ secrets.TEST_WALLET_PRIVATE_KEY }}
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,12 +41,11 @@ jobs:
       - name: Echo commit message
         run: echo "${{ steps.commit-message.outputs.value }}"
 
-      - uses: taichi/approved-event-action@v1.2.1
-        id: approved
-        with:
-          approvals: '2'
+      - name: Dump GitHub context
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_CONTEXT: ${{ toJSON(github) }}
+        run: echo "$GITHUB_CONTEXT"
+      - run: echo ${{ github.event.review.state }}
 
   install:
     name: Install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,10 +34,17 @@ jobs:
         with:
           fetch-depth: '50'
 
+      - name: Dump GitHub context
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+        run: |
+          echo "$GITHUB_CONTEXT"
+
       - name: Generate unique ID 💎
         id: uuid
-        run: echo "::set-output name=value::sha-$GITHUB_SHA-time-$(date +"%s")"
-
+        run: |
+          echo "::set-output name=value::sha-$GITHUB_SHA-time-$(date +"%s")"
+          echo "sha-$GITHUB_SHA-time-$(date +"%s")"
       - name: Get Commit Message
         id: commit-message
         run: |
@@ -50,7 +57,7 @@ jobs:
         id: check-if-tests-should-run
         continue-on-error: true
         with:
-          one_of: ready-for-tests
+          one_of: ready-for-tests, QA
           repo_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check if label is present
@@ -276,12 +283,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: '50'
-
-      - name: Dump GitHub context
-        env:
-          GITHUB_CONTEXT: ${{ toJson(github) }}
-        run: |
-          echo "$GITHUB_CONTEXT"
 
       - name: Set synpress default params
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Check if cypress tests should be executed
         id: cypress
-        if: ${{ ((github.event_name == 'push') || ((steps.label-present.outputs.value == 'true')&& !(github.actor == 'dependabot[bot]') && !(contains(steps.commit-message.outputs.value,'skip-cypress')) }}
+        if: ${{ ((github.event_name == 'push') || ((steps.label-present.outputs.value == 'true')&& !(github.actor == 'dependabot[bot]') && !(contains(steps.commit-message.outputs.value,'skip-cypress'))) }}
         run: |
           echo "Cypress tests should be executed"
           echo "::set-output name=value::true"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,7 @@ jobs:
         run: |
           echo "::set-output name=value::sha-$GITHUB_SHA-time-$(date +"%s")"
           echo "sha-$GITHUB_SHA-time-$(date +"%s")"
+
       - name: Get Commit Message
         id: commit-message
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Check if cypress tests should be executed
         id: cypress
-        if: ${{ ((github.event_name == 'push') || ((steps.label-present.outputs.value == 'true')&& !(github.actor == 'dependabot[bot]'))) }}
+        if: ${{ ((github.event_name == 'push') || ((steps.label-present.outputs.value == 'true')&& !(github.actor == 'dependabot[bot]') && !(contains(steps.commit-message.outputs.value,'skip-cypress')) }}
         run: |
           echo "Cypress tests should be executed"
           echo "::set-output name=value::true"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
         run: echo "${{ steps.commit-message.outputs.value }}"
 
       - name: approved-event-checker
-        uses: luisrjaeger/approved-event-checker@1.0.0
+        uses: taichi/approved-event-action@v1.2.1
         id: approved
         with:
           approvals: 1


### PR DESCRIPTION
As we already used 3/4 of test results capacity i changed a bit the way of executing tests, right now, unless there is no label 'ready-for-tests' label on pr the cypress smoke tests will not be executed.

![cach2](https://user-images.githubusercontent.com/30408272/189368443-84603a6d-fbe6-4775-9452-6e16f1212369.png)

This is temporary solution as i am researching possibility to switch to sorry-cypress 