### PR TITLE
Fix networks not working with WalletConnect

### DIFF
--- a/src/connectors/CustomWalletConnectConnector.ts
+++ b/src/connectors/CustomWalletConnectConnector.ts
@@ -39,12 +39,12 @@ export class CustomWalletConnectConnector extends AbstractConnector {
 
     this.config = config
 
-    this.handleChainChanged = this.handleChainChanged.bind(this)
+    this.changeChainId = this.changeChainId.bind(this)
     this.handleAccountsChanged = this.handleAccountsChanged.bind(this)
     this.handleDisconnect = this.handleDisconnect.bind(this)
   }
 
-  private handleChainChanged(chainId: number | string): void {
+  public changeChainId(chainId: number | string): void {
     this.emitUpdate({ chainId })
   }
 
@@ -57,7 +57,7 @@ export class CustomWalletConnectConnector extends AbstractConnector {
     // we have to do this because of a @walletconnect/web3-provider bug
     if (this.walletConnectProvider) {
       this.walletConnectProvider.stop()
-      this.walletConnectProvider.removeListener('chainChanged', this.handleChainChanged)
+      this.walletConnectProvider.removeListener('chainChanged', this.changeChainId)
       this.walletConnectProvider.removeListener('accountsChanged', this.handleAccountsChanged)
       this.walletConnectProvider = undefined
     }
@@ -87,8 +87,8 @@ export class CustomWalletConnectConnector extends AbstractConnector {
         throw error
       })
 
+    this.walletConnectProvider.on('chainChanged', this.changeChainId)
     this.walletConnectProvider.on('disconnect', this.handleDisconnect)
-    this.walletConnectProvider.on('chainChanged', this.handleChainChanged)
     this.walletConnectProvider.on('accountsChanged', this.handleAccountsChanged)
 
     return { provider: this.walletConnectProvider, account }
@@ -109,8 +109,8 @@ export class CustomWalletConnectConnector extends AbstractConnector {
   public deactivate() {
     if (this.walletConnectProvider) {
       this.walletConnectProvider.stop()
+      this.walletConnectProvider.removeListener('chainChanged', this.changeChainId)
       this.walletConnectProvider.removeListener('disconnect', this.handleDisconnect)
-      this.walletConnectProvider.removeListener('chainChanged', this.handleChainChanged)
       this.walletConnectProvider.removeListener('accountsChanged', this.handleAccountsChanged)
     }
   }

--- a/src/connectors/index.ts
+++ b/src/connectors/index.ts
@@ -42,6 +42,9 @@ export const injected = new InjectedConnector({
 // mainnet only
 export const walletConnect = new CustomWalletConnectConnector({
   rpc: {
+    [ChainId.OPTIMISM_MAINNET]: 'https://mainnet.optimism.io',
+    [ChainId.POLYGON]: 'https://polygon-rpc.com',
+    [ChainId.ARBITRUM_ONE]: 'https://arb1.arbitrum.io/rpc',
     [ChainId.XDAI]: 'https://rpc.gnosischain.com/',
     [ChainId.MAINNET]: `https://mainnet.infura.io/v3/${INFURA_PROJECT_ID}`,
   },

--- a/src/hooks/useNetworkSwitch.ts
+++ b/src/hooks/useNetworkSwitch.ts
@@ -5,6 +5,7 @@ import { useCallback } from 'react'
 import { NavigateFunction, useLocation, useNavigate } from 'react-router-dom'
 
 import { CustomNetworkConnector } from '../connectors/CustomNetworkConnector'
+import { CustomWalletConnectConnector } from '../connectors/CustomWalletConnectConnector'
 import { CustomWalletLinkConnector } from '../connectors/CustomWalletLinkConnector'
 import { NETWORK_DETAIL } from '../constants'
 import { switchOrAddNetwork } from '../utils'
@@ -35,6 +36,10 @@ export const useNetworkSwitch = ({ onSelectNetworkCallback }: UseNetworkSwitchPr
         changeChainIdResult = await switchOrAddNetwork(NETWORK_DETAIL[optionChainId], account || undefined)
       else if (connector instanceof CustomWalletLinkConnector)
         changeChainIdResult = await connector.changeChainId(NETWORK_DETAIL[optionChainId], account || undefined)
+      else if (connector instanceof CustomWalletConnectConnector) {
+        connector.changeChainId(optionChainId)
+        unavailableRedirect(optionChainId, navigate, pathname)
+      }
 
       if (onSelectNetworkCallback) onSelectNetworkCallback()
       // success scenario - user accepts the change on the popup window


### PR DESCRIPTION
# Summary

Fixes #940 

WalletConnect wallets were not connecting properly nor were they changing `chainId`s properly. Although the issue raised was with Arbitrum One, this PR seeks to address it for all chains.

  # To Test

1. Disconnect your wallet.
2. If needed, clear application data in development tools and stop Metamask from automatically connecting.
3. Connect your WalletConnect based wallet (I used Trust Wallet)
4. Change networks
5. I haven't tested this but... To confirm everything works, test a functionality. I suggest doing a swap in a low fee chain.

