### PR TITLE
fix: show enabled currency when not selected

### DIFF
--- a/src/components/SearchModal/CommonTokens/CommonTokens.component.tsx
+++ b/src/components/SearchModal/CommonTokens/CommonTokens.component.tsx
@@ -29,10 +29,7 @@ export const CommonTokens = ({ chainId, onCurrencySelect, selectedCurrency }: Co
         </TYPE.Body>
       </AutoRow>
       <AutoRow gap="4px">
-        <BaseWrapper
-          onClick={handleClick}
-          disabled={selectedCurrency === nativeCurrency || selectedCurrency === undefined}
-        >
+        <BaseWrapper onClick={handleClick} disabled={selectedCurrency === nativeCurrency}>
           <CurrencyLogo size="20px" currency={nativeCurrency} marginRight={8} />
           <Text fontWeight={500} fontSize={16}>
             {nativeCurrency.symbol}

--- a/src/components/SearchModal/CurrencyList/CurrencyList.component.tsx
+++ b/src/components/SearchModal/CurrencyList/CurrencyList.component.tsx
@@ -178,7 +178,8 @@ export const CurrencyList = ({
       if (currency && currency instanceof Currency) {
         const isSelected = Boolean(selectedCurrency && currencyEquals(selectedCurrency, currency))
         const otherSelected = Boolean(otherCurrency && otherCurrency.some(c => currencyEquals(c, currency)))
-        const handleSelect = () => onCurrencySelect(currency)
+        const handleSelect = () => !isSelected && onCurrencySelect(currency)
+
         return (
           <CurrencyRow
             selectedTokenList={selectedTokenList}


### PR DESCRIPTION
# Summary

Fixes #1455

Show enabled currency when not selected

![image](https://user-images.githubusercontent.com/23079677/189903217-745fdc93-9d84-43b8-9e42-e6615b50f639.png)

# Background

I don't know if this is the desired solution. There is a different logic for `common token list` and `all token list`.
