### PR TITLE
Add missing external link icon on navbar "vote"

### DIFF
--- a/src/components/Header/MobileOptions.tsx
+++ b/src/components/Header/MobileOptions.tsx
@@ -78,22 +78,21 @@ export default function MobileOptions() {
         show={open}
         placement="bottom-end"
         content={
-          <>
-            <List>
-              <ListItem>
-                <StyledExternalLink id="charts-nav-link" href="https://dxstats.eth.limo/">
-                  {t('charts')}
-                  <span>↗</span>
-                </StyledExternalLink>
-              </ListItem>
+          <List>
+            <ListItem>
+              <StyledExternalLink id="charts-nav-link" href="https://dxstats.eth.limo/">
+                {t('charts')}
+                <span>↗</span>
+              </StyledExternalLink>
+            </ListItem>
 
-              <ListItem>
-                <StyledExternalLink id="stake-nav-link" href="https://snapshot.org/#/swpr.eth">
-                  {t('vote')}
-                </StyledExternalLink>
-              </ListItem>
-            </List>
-          </>
+            <ListItem>
+              <StyledExternalLink id="stake-nav-link" href="https://snapshot.org/#/swpr.eth">
+                {t('vote')}
+                <span>↗</span>
+              </StyledExternalLink>
+            </ListItem>
+          </List>
         }
       >
         <MenuButton onClick={toggle}>{open ? <Cross /> : <ThreeBars />}</MenuButton>

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -272,21 +272,20 @@ function Header() {
             {networkWithoutSWPR && <HeaderLinkBadge label="NOT&nbsp;AVAILABLE" />}
           </HeaderLink>
           <HeaderLink data-testid="bridge-nav-link" id="bridge-nav-link" to="/bridge">
-            <>
-              {t('bridge')}
-              <HeaderLinkBadge label="BETA" />
-            </>
+            {t('bridge')}
+            <HeaderLinkBadge label="BETA" />
           </HeaderLink>
-          <HeaderLink id="vote-nav-link" href={`https://snapshot.org/#/swpr.eth`}>
+          <HeaderLink id="vote-nav-link" href="https://snapshot.org/#/swpr.eth">
             {t('vote')}
+            <Text ml="4px" fontSize="13px">
+              ↗
+            </Text>
           </HeaderLink>
           <HeaderLink id="charts-nav-link" href={`https://dxstats.eth.limo/#/?chainId=${chainId}`}>
-            <>
-              {t('charts')}
-              <Text ml="4px" fontSize="11px">
-                ↗
-              </Text>
-            </>
+            {t('charts')}
+            <Text ml="4px" fontSize="13px">
+              ↗
+            </Text>
           </HeaderLink>
         </HeaderLinks>
       </HeaderRow>
@@ -355,14 +354,15 @@ function Header() {
           </HeaderMobileLink>
           <HeaderMobileLink id="vote-nav-link" href={`https://snapshot.org/#/swpr.eth`}>
             {t('vote')}
+            <Text ml="4px" fontSize="11px">
+              ↗
+            </Text>
           </HeaderMobileLink>
           <HeaderMobileLink id="stake-nav-link" href={`https://dxstats.eth.limo/#/?chainId=${chainId}`}>
-            <>
-              {t('charts')}
-              <Text ml="4px" fontSize="11px">
-                ↗
-              </Text>
-            </>
+            {t('charts')}
+            <Text ml="4px" fontSize="11px">
+              ↗
+            </Text>
           </HeaderMobileLink>
         </Flex>
 


### PR DESCRIPTION
# Summary
Links should express when link to external sources.

Add missing external link icon on navbar "vote"

**Before**
<img width="501" alt="image" src="https://user-images.githubusercontent.com/5664434/192331460-3a067e52-0b64-4597-ae32-969132d9004a.png">

**Now**
<img width="489" alt="image" src="https://user-images.githubusercontent.com/5664434/192331275-8c3683d2-4e67-4eca-8f6c-4aa0182a2c7d.png">


  # To Test

1. Open swapr
- [ ] Check navbar "vote" has a external link icon