### PR TITLE
Update landing page text referring to the eco bridge

### DIFF
--- a/src/utils/ui-constants.js
+++ b/src/utils/ui-constants.js
@@ -244,7 +244,7 @@ export const FeaturesContent = {
     },
     {
       title: 'BRIDGE',
-      content: 'Bridge directly to or from any chain where Swapr is deployed.',
+      content: 'Bridge directly to or from multiple chains: Ethereum, Gnosis, Arbitrum, Polygon, Optimism.',
       image: Bridge,
       animation: animations['06_Bridge'],
       buttons: [


### PR DESCRIPTION
# Summary

fixes #1363 

Update landing page text referring to the eco bridge.

<img width="572" alt="image" src="https://user-images.githubusercontent.com/5664434/192345652-81e1ce53-1056-4a93-8b6c-5fc1c681034c.png">

 # To Test

1. Open swapr
- [ ] Check if landing eco-bridge text is correct.
