### PR TITLE
update explorer to gnosisscan

### DIFF
--- a/src/constants/index.tsx
+++ b/src/constants/index.tsx
@@ -449,7 +449,7 @@ export const NETWORK_DETAIL: { [chainId: number]: NetworkDetails } = {
       decimals: Currency.XDAI.decimals || 18,
     },
     rpcUrls: ['https://rpc.gnosischain.com/'],
-    blockExplorerUrls: ['https://blockscout.com/xdai/mainnet'],
+    blockExplorerUrls: ['https://gnosisscan.io'],
   },
   [ChainId.ARBITRUM_ONE]: {
     chainId: `0x${ChainId.ARBITRUM_ONE.toString(16)}`,

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -39,7 +39,7 @@ const getExplorerPrefix = (chainId: ChainId) => {
     case ChainId.ARBITRUM_RINKEBY:
       return 'https://testnet.arbiscan.io'
     case ChainId.XDAI:
-      return 'https://blockscout.com/xdai/mainnet'
+      return 'https://gnosisscan.io'
     case ChainId.POLYGON:
       return 'https://polygonscan.com'
     case ChainId.OPTIMISM_MAINNET:

--- a/tests/utils/MetamaskNetworkHandler.ts
+++ b/tests/utils/MetamaskNetworkHandler.ts
@@ -7,7 +7,7 @@ export class MetamaskNetworkHandler {
       rpcUrl: 'https://rpc.gnosischain.com/',
       chainId: '100',
       symbol: 'xDai',
-      blockExplorer: 'https://blockscout.com/xdai/mainnet',
+      blockExplorer: 'https://gnosisscan.io',
       isTestnet: true,
     })
   }


### PR DESCRIPTION
# Summary

Fixes #1550 

This updates blockscout explorer URLs to gnosisscan.io 
There is still one place where we use blockscout. We do gasesatimations with blockscout API and there is no equivalent one in Gnosis scan yet that provides Fast / Normal / Slow. I hope its okay to do that later as a seperate PR.

  # To Test
1. Test from transactions page
2. Test by adding Gnosischain network to Metamask.
3. Test in the transaction submitted modal and the 5 second toast that displays.
4. Test the address / transactions within metamask to see if explorer is added properly in metamask.
