### PR TITLE
add socketscan to getExplorerLink function

### DIFF
--- a/src/pages/Account/TransactionRows/BridgeTransactionRow.tsx
+++ b/src/pages/Account/TransactionRows/BridgeTransactionRow.tsx
@@ -27,9 +27,11 @@ export function BridgeTransactionRow({ transaction }: BridgeTransactionRowProps)
   const fromNetwork = from.chainId ? getNetworkInfo(Number(from.chainId)) : undefined
   const toNetwork = to?.chainId ? getNetworkInfo(Number(to?.chainId)) : undefined
 
-  const fromLink = getExplorerLink(logs[0]?.chainId, logs[0]?.txHash, 'transaction')
+  const fromLink = getExplorerLink(logs[0]?.chainId, logs[0]?.txHash, 'transaction', bridgeId)
   const toLink =
-    logs[1]?.chainId && logs[1]?.txHash ? getExplorerLink(logs[1]?.chainId, logs[1]?.txHash, 'transaction') : undefined
+    logs[1]?.chainId && logs[1]?.txHash
+      ? getExplorerLink(logs[1]?.chainId, logs[1]?.txHash, 'transaction', bridgeId)
+      : undefined
 
   return (
     <GridCard status={status.toUpperCase()}>

--- a/src/pages/Account/TransactionRows/BridgeTransactionRow.tsx
+++ b/src/pages/Account/TransactionRows/BridgeTransactionRow.tsx
@@ -29,9 +29,9 @@ export function BridgeTransactionRow({ transaction }: BridgeTransactionRowProps)
 
   const fromLink = getExplorerLink(logs[0]?.chainId, logs[0]?.txHash, 'transaction', bridgeId)
   const toLink =
-    logs[1]?.chainId && logs[1]?.txHash
-      ? getExplorerLink(logs[1]?.chainId, logs[1]?.txHash, 'transaction', bridgeId)
-      : undefined
+    bridgeId === 'socket'
+      ? logs[0] && logs[1] && getExplorerLink(logs[0].chainId, logs[0].txHash, 'transaction', bridgeId)
+      : logs[1] && getExplorerLink(logs[1].chainId, logs[1].txHash, 'transaction', bridgeId)
 
   return (
     <GridCard status={status.toUpperCase()}>

--- a/src/pages/Bridge/BridgeTransactionsSummary.tsx
+++ b/src/pages/Bridge/BridgeTransactionsSummary.tsx
@@ -176,7 +176,7 @@ const BridgeTransactionsSummaryRow = ({ tx, handleTriggerCollect }: BridgeTransa
       <ColumnFrom data-testid="bridged-from-chain">
         <TextFrom>
           <Link
-            href={getExplorerLink(log[0].chainId, log[0].txHash, 'transaction')}
+            href={getExplorerLink(log[0].chainId, log[0].txHash, 'transaction', tx.bridgeId)}
             rel="noopener noreferrer"
             target="_blank"
           >
@@ -191,7 +191,7 @@ const BridgeTransactionsSummaryRow = ({ tx, handleTriggerCollect }: BridgeTransa
         </Filler>
         <TextTo
           status={status}
-          href={log[1] && getExplorerLink(log[1].chainId, log[1].txHash, 'transaction')}
+          href={(log[1] && getExplorerLink(log[1].chainId, log[1].txHash, 'transaction'), tx.bridgeId)}
           rel="noopener noreferrer"
           target="_blank"
         >

--- a/src/pages/Bridge/BridgeTransactionsSummary.tsx
+++ b/src/pages/Bridge/BridgeTransactionsSummary.tsx
@@ -162,9 +162,14 @@ interface BridgeTransactionsSummaryRowProps {
 }
 
 const BridgeTransactionsSummaryRow = ({ tx, handleTriggerCollect }: BridgeTransactionsSummaryRowProps) => {
-  const { assetName, fromChainId, status, toChainId, fromValue, pendingReason, log } = tx
+  const { assetName, fromChainId, status, toChainId, fromValue, pendingReason, log, bridgeId } = tx
   const fromChainName = getNetworkInfo(fromChainId).name
   const toChainName = getNetworkInfo(toChainId).name
+
+  const toLink =
+    bridgeId === 'socket'
+      ? log[0] && log[1] && getExplorerLink(log[0].chainId, log[0].txHash, 'transaction', bridgeId)
+      : log[1] && getExplorerLink(log[1].chainId, log[1].txHash, 'transaction', bridgeId)
 
   return (
     <Row>
@@ -176,7 +181,7 @@ const BridgeTransactionsSummaryRow = ({ tx, handleTriggerCollect }: BridgeTransa
       <ColumnFrom data-testid="bridged-from-chain">
         <TextFrom>
           <Link
-            href={getExplorerLink(log[0].chainId, log[0].txHash, 'transaction', tx.bridgeId)}
+            href={getExplorerLink(log[0].chainId, log[0].txHash, 'transaction', bridgeId)}
             rel="noopener noreferrer"
             target="_blank"
           >
@@ -189,12 +194,7 @@ const BridgeTransactionsSummaryRow = ({ tx, handleTriggerCollect }: BridgeTransa
           <Dots status={BridgeTransactionStatus.CONFIRMED} />
           <Dots status={status} />
         </Filler>
-        <TextTo
-          status={status}
-          href={(log[1] && getExplorerLink(log[1].chainId, log[1].txHash, 'transaction'), tx.bridgeId)}
-          rel="noopener noreferrer"
-          target="_blank"
-        >
+        <TextTo status={status} href={toLink} rel="noopener noreferrer" target="_blank">
           {toChainName}
         </TextTo>
       </ColumnToFlex>

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -60,6 +60,8 @@ export function getExplorerLink(
     return getGnosisProtocolExplorerOrderLink(chainId, hash)
   }
 
+  if (protocol === 'socket') return getSocketExplorerLink(hash)
+
   const prefix = getExplorerPrefix(chainId)
   // exception. blockscout doesn't have a token-specific address
   if (chainId === ChainId.XDAI && type === 'token') {
@@ -257,6 +259,10 @@ export const normalizeInputValue = (val: string, strictFormat?: boolean) => {
   return strictFormat
     ? normalizedValue.replace(/^([\d,]+)$|^([\d,]+)\.0*$|^([\d,]+\.[0-9]*?)0*$/, '$1$2$3')
     : normalizedValue
+}
+
+export function getSocketExplorerLink(transactionHash: string) {
+  return `https://socketscan.io/tx/${transactionHash}`
 }
 
 /**


### PR DESCRIPTION
# Summary

Add SocketScan


# To Test
1. Open `Bridge` page
2. Do transaction through `Socket`
3. If transaction is completed, click on `fromChainId`
4. It should redirect user to `https://socketscan.io/`
5. Check it on `Dashboard` as well

NOTE: Socketscan currently only supports search using source transaction hash.  



