### PR TITLE
hotfix: remove testnets in network switcher and bridge network selector

### DIFF
--- a/src/components/NetworkSwitcher/NetworkSwitcher.preset.ts
+++ b/src/components/NetworkSwitcher/NetworkSwitcher.preset.ts
@@ -40,6 +40,12 @@ export const networkOptionsPreset: NetworkOptionsPreset[] = [
     logoSrc: BinanceChainLogo,
     color: '#F3BA2F',
   },
+  {
+    chainId: ChainId.XDAI,
+    name: 'Gnosis Chain',
+    logoSrc: GnosisLogo,
+    color: '#49A9A7',
+  },
 
   // TESTNETS
   {
@@ -69,12 +75,6 @@ export const networkOptionsPreset: NetworkOptionsPreset[] = [
     logoSrc: ArbitrumLogo,
     color: '#b1a5e6',
     tag: NetworkSwitcherTags.TESTNETS,
-  },
-  {
-    chainId: ChainId.XDAI,
-    name: 'Gnosis Chain',
-    logoSrc: GnosisLogo,
-    color: '#49A9A7',
   },
   {
     chainId: ChainId.OPTIMISM_GOERLI,

--- a/src/constants/index.tsx
+++ b/src/constants/index.tsx
@@ -727,6 +727,7 @@ export const TESTNETS = [
   ChainId.ARBITRUM_GOERLI,
   ChainId.OPTIMISM_GOERLI,
   ChainId.GOERLI,
+  ChainId.BSC_TESTNET,
 ]
 
 export const SHOW_TESTNETS = false

--- a/src/pages/Bridge/index.tsx
+++ b/src/pages/Bridge/index.tsx
@@ -1,4 +1,4 @@
-import { CurrencyAmount } from '@swapr/sdk'
+import { ChainId, CurrencyAmount } from '@swapr/sdk'
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
@@ -98,6 +98,23 @@ const OutputPanelContainer = styled.div`
   margin-top: 12px;
 `
 
+/**
+ * Checks if network is supported by the bridge.
+ * Checks if the network exists in the defined presets.
+ * Checks if the network has testnet or coming soon tag.
+ * @param chainId
+ */
+export function isNetworkSupported(chainId: ChainId): boolean {
+  const network = networkOptionsPreset.find(network => network.chainId === chainId)
+
+  if (!network) {
+    return false
+  }
+
+  // Check for tags
+  return network.tag === NetworkSwitcherTags.COMING_SOON || network.tag === NetworkSwitcherTags.TESTNETS
+}
+
 export default function Bridge() {
   const dispatch = useDispatch()
   const { chainId, account } = useActiveWeb3React()
@@ -152,8 +169,7 @@ export default function Bridge() {
 
   const [displayedValue, setDisplayedValue] = useState('')
 
-  const isUnsupportedBridgeNetwork =
-    networkOptionsPreset.find(network => network.chainId === chainId)?.tag === NetworkSwitcherTags.COMING_SOON
+  const isUnsupportedBridgeNetwork = !isNetworkSupported(chainId!)
 
   useEffect(() => {
     if (activeTab === BridgeTab.BRIDGE) {
@@ -280,7 +296,7 @@ export default function Bridge() {
         onNetworkChange: onFromNetworkChange,
         selectedNetworkChainId: isCollecting && collectableTx ? collectableTx.fromChainId : fromChainId,
         activeChainId: account ? chainId : -1,
-        showTestnets: true,
+        showTestnets: false,
       }),
     [account, chainId, collectableTx, isCollecting, fromChainId, onFromNetworkChange]
   )
@@ -293,7 +309,7 @@ export default function Bridge() {
         onNetworkChange: onToNetworkChange,
         selectedNetworkChainId: isCollecting && collectableTx ? collectableTx.toChainId : toChainId,
         activeChainId: account ? chainId : -1,
-        showTestnets: true,
+        showTestnets: false,
       }),
     [account, chainId, collectableTx, isCollecting, onToNetworkChange, toChainId]
   )


### PR DESCRIPTION
# Summary

- Disables testnets in Bridge form 
- Remove BNB chain in network switcher