### PR TITLE
feature: show three decimals on bridge box

### DIFF
--- a/src/services/EcoBridge/Arbitrum/ArbitrumBridge.tsx
+++ b/src/services/EcoBridge/Arbitrum/ArbitrumBridge.tsx
@@ -913,7 +913,7 @@ export class ArbitrumBridge extends EcoBridgeChildBase {
         gas: totalTxnGasCostInUSD,
         fee: '0%',
         estimateTime: this.l1ChainId === this._activeChainId ? '10 min' : '7 days',
-        receiveAmount: Number(value).toFixed(2).toString(),
+        receiveAmount: Number(value).toFixed(this._receiveAmountDecimalPlaces).toString(),
         requestId: helperRequestId,
       })
     )

--- a/src/services/EcoBridge/Connext/Connext.ts
+++ b/src/services/EcoBridge/Connext/Connext.ts
@@ -484,7 +484,7 @@ export class Connext extends EcoBridgeChildBase {
       }
 
       const details = {
-        receiveAmount: Number(formatUnits(amountReceived, decimals)).toFixed(2),
+        receiveAmount: Number(formatUnits(amountReceived, decimals)).toFixed(this._receiveAmountDecimalPlaces),
         fee,
         estimateTime: '15 MIN',
         requestId: helperRequestId,

--- a/src/services/EcoBridge/EcoBridge.utils.tsx
+++ b/src/services/EcoBridge/EcoBridge.utils.tsx
@@ -17,6 +17,7 @@ export abstract class EcoBridgeChildBase {
   protected _activeChainId: EcoBridgeChildBaseProps['activeChainId']
   protected _staticProviders: EcoBridgeChildBaseProps['staticProviders']
   protected _activeProvider: EcoBridgeChildBaseProps['activeProvider']
+  protected readonly _receiveAmountDecimalPlaces = 3
 
   constructor({ supportedChains, bridgeId, displayName }: EcoBridgeChildBaseConstructor) {
     this.bridgeId = bridgeId

--- a/src/services/EcoBridge/OmniBridge/OmniBridge.ts
+++ b/src/services/EcoBridge/OmniBridge/OmniBridge.ts
@@ -684,7 +684,9 @@ export class OmniBridge extends EcoBridgeChildBase {
     const details = {
       fee,
       gas,
-      receiveAmount: Number(formatUnits(toAmount.toString(), toTokenDecimals)).toFixed(2),
+      receiveAmount: Number(formatUnits(toAmount.toString(), toTokenDecimals)).toFixed(
+        this._receiveAmountDecimalPlaces
+      ),
       estimateTime: '5 min',
       requestId: helperRequestId,
     }

--- a/src/services/EcoBridge/Socket/SocketBridge.ts
+++ b/src/services/EcoBridge/Socket/SocketBridge.ts
@@ -418,7 +418,9 @@ export class SocketBridge extends EcoBridgeChildBase {
 
     const { toAmount, serviceTime, totalGasFeesInUsd, routeId } = bestRoute
 
-    const formattedToAmount = Number(formatUnits(toAmount, result.toAsset.decimals)).toFixed(2).toString()
+    const formattedToAmount = Number(formatUnits(toAmount, result.toAsset.decimals))
+      .toFixed(this._receiveAmountDecimalPlaces)
+      .toString()
 
     this.store.dispatch(commonActions.setActiveRouteId(routeId))
 

--- a/src/services/EcoBridge/Xdai/XdaiBridge.ts
+++ b/src/services/EcoBridge/Xdai/XdaiBridge.ts
@@ -162,7 +162,7 @@ export class XdaiBridge extends EcoBridgeChildBase {
       gas,
       fee: '0%',
       estimateTime: '5 min',
-      receiveAmount: Number(value).toFixed(2),
+      receiveAmount: Number(value).toFixed(this._receiveAmountDecimalPlaces),
       requestId: helperRequestId,
     }
 


### PR DESCRIPTION
# Summary

Fixes #1258

Show 3 decimals on bridge box, instead of 2.

![image](https://user-images.githubusercontent.com/23079677/199484013-d25f688b-22e7-4841-a96a-74557811222f.png)

 # To Test

1. Go to bridge and input an amount
- [ ] Bridge options should have 3 decimal places on the amount value

