### PR TITLE
hotfix: Fix pool page from breaking and shows 24h volume on Arbitrum

### DIFF
--- a/src/hooks/usePairVolume24hUSD.ts
+++ b/src/hooks/usePairVolume24hUSD.ts
@@ -118,10 +118,8 @@ export function usePair24hVolumeUSD(
   return useMemo(() => {
     if (volume24hUsdLoading || totalVolumeLoading || blockLoading) return { loading: true, volume24hUSD: ZERO_USD }
     if (
-      !volume24hUsdData ||
-      !totalVolumeData ||
-      !volume24hUsdData.pairs.length ||
-      !totalVolumeData.pairs.length ||
+      !volume24hUsdData?.pairs?.length ||
+      !totalVolumeData?.pairs?.length ||
       volume24hUsdError ||
       totalVolumeError ||
       blockError

--- a/src/hooks/usePairVolume24hUSD.ts
+++ b/src/hooks/usePairVolume24hUSD.ts
@@ -13,7 +13,7 @@ import { SWPRSupportedChains } from '../utils/chainSupportsSWPR'
 
 const GET_BLOCK_BY_TIMESTAMP = gql`
   query getBlockFromTimestamp($timestamp: String!) {
-    blocks(first: 10, orderBy: number, orderDirection: asc, where: { timestamp_gt: $timestamp }) {
+    blocks(first: 999, orderBy: number, orderDirection: asc, where: { timestamp_gt: $timestamp }) {
       number
     }
   }


### PR DESCRIPTION
# Summary

This PR fixes the page breaking and showing 24h volume. 

fixes #1577

<img width="1456" alt="image" src="https://user-images.githubusercontent.com/5664434/199987397-840972ba-2239-4f45-9933-a3d6cca333a3.png">


  # To Test

1. <<Step one>> Open the page `about`
- [ ] <<What to expect?>> Verify it contains about information...
- [ ] Checkbox Style list of things a QA person could verify, i.e.
- [ ] Should display Text Input our storybook
- [ ] Input should not accept Numbers
2. <<Step two>> ...

  # Background

*Optional: Give background information for changes you've made, that might be difficult to explain via comments*

