### PR TITLE
fix: improve advanced trading view

### DIFF
--- a/public/locales/en/swap.json
+++ b/public/locales/en/swap.json
@@ -57,5 +57,6 @@
   "advancedTradingView.orderHistory.type": "Type",
   "advancedTradingView.orderHistory.protocol": "Protocol",
   "advancedTradingView.orderHistory.date": "Date",
-  "advancedTradingView.orderHistory.status": "Status"
+  "advancedTradingView.orderHistory.status": "Status",
+  "advancedTradingView.orderHistory.tx": "Tx"
 }

--- a/src/pages/Swap/AdvancedSwapMode/AdvancedSwapMode.component.tsx
+++ b/src/pages/Swap/AdvancedSwapMode/AdvancedSwapMode.component.tsx
@@ -136,6 +136,7 @@ export const AdvancedSwapMode = ({ children }: PropsWithChildren) => {
               <Text>{t('advancedTradingView.orderHistory.type')}</Text>
               <Text>{t('advancedTradingView.orderHistory.date')}</Text>
               <Text>{t('advancedTradingView.orderHistory.status')}</Text>
+              <Text>{t('advancedTradingView.orderHistory.tx')}</Text>
             </OrderHistoryHeader>
             {transactions.map((tx, index) => (
               <OrderHistoryTransaction key={index} tx={tx} />
@@ -158,8 +159,8 @@ export const AdvancedSwapMode = ({ children }: PropsWithChildren) => {
           <ColumnHeader
             activeCurrencySymbolOption={activeCurrencyOption?.symbol ?? ''}
             showPrice={false}
-            inputTokenSymbol={inputToken?.symbol ?? ''}
-            outputTokenSymbol={outputToken?.symbol ?? ''}
+            inputTokenSymbol={token0?.symbol ?? ''}
+            outputTokenSymbol={token1?.symbol ?? ''}
             showTrades={showTrades}
           />
         </AdvancedModeHeader>

--- a/src/pages/Swap/AdvancedSwapMode/AdvancedSwapMode.component.tsx
+++ b/src/pages/Swap/AdvancedSwapMode/AdvancedSwapMode.component.tsx
@@ -69,12 +69,7 @@ export const AdvancedSwapMode = ({ children }: PropsWithChildren) => {
   return (
     <AdvancedSwapModeWrapper>
       <PairDetailsWrapper>
-        <PairDetails
-          token0={token0}
-          token1={token1}
-          activeCurrencyOption={inputToken}
-          isLatestTradeSell={!!tradeHistory[0]?.isSell}
-        />
+        <PairDetails token0={token0} token1={token1} activeCurrencyOption={inputToken} />
       </PairDetailsWrapper>
       <ChartWrapper>
         <Chart symbol={symbol} />

--- a/src/pages/Swap/AdvancedSwapMode/AdvancedSwapMode.styles.ts
+++ b/src/pages/Swap/AdvancedSwapMode/AdvancedSwapMode.styles.ts
@@ -216,11 +216,13 @@ export const OrderHistoryHeader = styled.div`
   text-transform: uppercase;
 
   & > div {
-    flex: 1;
+    flex: 2;
     color: ${({ theme }) => theme.purple3};
+    padding-right: 4px;
   }
 
   & > div:last-child {
     text-align: right;
+    flex: 1;
   }
 `

--- a/src/pages/Swap/AdvancedSwapMode/AdvancedSwapMode.styles.ts
+++ b/src/pages/Swap/AdvancedSwapMode/AdvancedSwapMode.styles.ts
@@ -67,8 +67,8 @@ export const PairInfo = styled.div`
   margin-left: 20px;
   overflow: hidden;
   white-space: nowrap;
-  &:nth-child(2) {
-    width: 16%;
+  &:nth-child(-n + 2) {
+    width: 13%;
   }
 
   & > div:nth-child(2) {

--- a/src/pages/Swap/AdvancedSwapMode/Chart/Chart.component.tsx
+++ b/src/pages/Swap/AdvancedSwapMode/Chart/Chart.component.tsx
@@ -1,17 +1,23 @@
 import { memo } from 'react'
 import { AdvancedRealTimeChart } from 'react-ts-tradingview-widgets'
 
+import { Wrapper } from './Chart.styles'
+import { ChartLoader } from './ChartLoader.component'
+
 export const Chart = memo(({ symbol }: { symbol?: string }) => {
   return (
-    <AdvancedRealTimeChart
-      symbol={symbol ?? 'USDCUSD'}
-      theme="dark"
-      style="8" // eslint-disable-line
-      autosize
-      allow_symbol_change={false}
-      disabled_features={['header_chart_type', 'header_compare', 'header_indicators']}
-      copyrightStyles={{ parent: { display: 'none' } }}
-      interval="60"
-    />
+    <Wrapper>
+      <AdvancedRealTimeChart
+        symbol={symbol ?? 'USDCUSD'}
+        theme="dark"
+        style="8" // eslint-disable-line
+        autosize
+        allow_symbol_change={false}
+        disabled_features={['header_chart_type', 'header_compare', 'header_indicators']}
+        copyrightStyles={{ parent: { display: 'none' } }}
+        interval="60"
+      />
+      <ChartLoader symbol={symbol} />
+    </Wrapper>
   )
 })

--- a/src/pages/Swap/AdvancedSwapMode/Chart/Chart.styles.tsx
+++ b/src/pages/Swap/AdvancedSwapMode/Chart/Chart.styles.tsx
@@ -1,0 +1,17 @@
+import styled from 'styled-components'
+
+export const Wrapper = styled.div`
+  position: relative;
+  widht: 100%;
+  height: 100%;
+`
+
+export const AbsoluteWrapper = styled.div`
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+  z-index: 1;
+  background: ${({ theme }) => theme.bg9};
+`

--- a/src/pages/Swap/AdvancedSwapMode/Chart/ChartLoader.component.tsx
+++ b/src/pages/Swap/AdvancedSwapMode/Chart/ChartLoader.component.tsx
@@ -1,0 +1,22 @@
+import { useEffect, useState } from 'react'
+
+import { FallbackLoader } from '../../../../components/Loader/FallbackLoader'
+import { AbsoluteWrapper } from './Chart.styles'
+
+const THREE_SECONDS = 3000
+
+export function ChartLoader({ symbol }: { symbol?: string }) {
+  const [isLoading, setIsLoading] = useState(true)
+
+  useEffect(() => {
+    setIsLoading(true)
+    const timeout = setTimeout(() => setIsLoading(false), THREE_SECONDS)
+    return () => clearTimeout(timeout)
+  }, [symbol])
+
+  return symbol && isLoading ? (
+    <AbsoluteWrapper>
+      <FallbackLoader />
+    </AbsoluteWrapper>
+  ) : null
+}

--- a/src/pages/Swap/AdvancedSwapMode/OrderHistory/OrderHistoryTransaction/OrderHistoryTransaction.tsx
+++ b/src/pages/Swap/AdvancedSwapMode/OrderHistory/OrderHistoryTransaction/OrderHistoryTransaction.tsx
@@ -66,7 +66,7 @@ export const OrderHistoryTransaction = ({ tx }: { tx: Transaction }) => {
       <div>
         {isSwapTransaction ? (
           <a
-            href={chainId && getExplorerLink(chainId, tx.hash, EXPLORER_LINK_TYPE.transaction)}
+            href={chainId && getExplorerLink(chainId, tx.hash, EXPLORER_LINK_TYPE.transaction, tx.swapProtocol)}
             rel="noopener noreferrer"
             target="_blank"
           >

--- a/src/pages/Swap/AdvancedSwapMode/OrderHistory/OrderHistoryTransaction/OrderHistoryTransaction.tsx
+++ b/src/pages/Swap/AdvancedSwapMode/OrderHistory/OrderHistoryTransaction/OrderHistoryTransaction.tsx
@@ -1,7 +1,10 @@
 import { DateTime } from 'luxon'
+import { ExternalLink } from 'react-feather'
 import { Text } from 'rebass'
-import styled from 'styled-components'
+import styled, { useTheme } from 'styled-components'
 
+import { useActiveWeb3React } from '../../../../../hooks/index'
+import { EXPLORER_LINK_TYPE, getExplorerLink } from '../../../../../utils'
 import { Status } from '../../../../Account/Account.styles'
 import { Transaction, TransactionTypes } from '../../../../Account/Account.types'
 import { TokenIcon } from '../../../../Account/TokenIcon'
@@ -12,12 +15,14 @@ const Wrapper = styled.div`
   margin-top: 20px;
 
   & > div {
-    flex: 1;
+    flex: 2;
     display: flex;
     align-items: center;
+    padding-right: 4px;
   }
   & > div:last-child {
     justify-content: flex-end;
+    flex: 1;
   }
 
   font-size: 12px;
@@ -25,6 +30,9 @@ const Wrapper = styled.div`
 `
 
 export const OrderHistoryTransaction = ({ tx }: { tx: Transaction }) => {
+  const { chainId } = useActiveWeb3React()
+  const theme = useTheme()
+
   const isSwapTransaction = tx.type === TransactionTypes.Swap
 
   const protocol = isSwapTransaction ? tx.swapProtocol ?? 'Swapr' : 'Socket'
@@ -46,7 +54,7 @@ export const OrderHistoryTransaction = ({ tx }: { tx: Transaction }) => {
         {tx.confirmedTime ? (
           <>
             {DateTime.fromMillis(tx.confirmedTime).toFormat('dd/MM/yyyy')}{' '}
-            {DateTime.fromMillis(tx.confirmedTime).toFormat('HH:mm:ss')}
+            {DateTime.fromMillis(tx.confirmedTime).toFormat('HH:mm')}
           </>
         ) : (
           '-'
@@ -54,6 +62,19 @@ export const OrderHistoryTransaction = ({ tx }: { tx: Transaction }) => {
       </div>
       <div>
         <Status status={tx.status.toUpperCase()}>{tx.status}</Status>
+      </div>
+      <div>
+        {isSwapTransaction ? (
+          <a
+            href={chainId && getExplorerLink(chainId, tx.hash, EXPLORER_LINK_TYPE.transaction)}
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <ExternalLink size="15" color={theme.text4} />
+          </a>
+        ) : (
+          '-'
+        )}
       </div>
     </Wrapper>
   )

--- a/src/pages/Swap/AdvancedSwapMode/PairDetails/PairDetails.component.tsx
+++ b/src/pages/Swap/AdvancedSwapMode/PairDetails/PairDetails.component.tsx
@@ -14,10 +14,9 @@ interface PairDetailsProps {
   token0?: Token
   token1?: Token
   activeCurrencyOption: Token | null | undefined
-  isLatestTradeSell: boolean
 }
 
-export const PairDetails = ({ token0, token1, activeCurrencyOption, isLatestTradeSell }: PairDetailsProps) => {
+export const PairDetails = ({ token0, token1, activeCurrencyOption }: PairDetailsProps) => {
   const { t } = useTranslation('swap')
 
   const { activeCurrencyDetails, handleOpenModal, isLoading, isPairModalOpen, onDismiss, onPairSelect, volume24hUSD } =
@@ -37,7 +36,7 @@ export const PairDetails = ({ token0, token1, activeCurrencyOption, isLatestTrad
         </Flex>
         <Flex flexBasis="80%" marginLeft="30px">
           <PairInfo>
-            <PairValueChange size="16px" positive={!isLatestTradeSell}>
+            <PairValueChange size="16px" positive={Boolean(activeCurrencyDetails.isIncome24h)}>
               {isLoading ? <Skeleton width="100px" height="14px" /> : activeCurrencyDetails.relativePrice}
             </PairValueChange>
             <PairTab>{isLoading ? <Skeleton width="100px" height="14px" /> : activeCurrencyDetails.price}</PairTab>

--- a/src/pages/Swap/AdvancedSwapMode/Trade/Trade.component.tsx
+++ b/src/pages/Swap/AdvancedSwapMode/Trade/Trade.component.tsx
@@ -59,7 +59,7 @@ export const Trade = ({
       <Text>{amountOut}</Text>
       {price && <Text>{price}</Text>}
       <Text sx={{ textTransform: 'uppercase', textAlign: 'right', color: '#BCB3F0' }}>
-        {DateTime.fromMillis(timestampInMilliseconds).toFormat('HH:mm:ss')}
+        {DateTime.fromMillis(timestampInMilliseconds).toFormat('HH:mm')}
       </Text>
     </TradeWrapper>
   )

--- a/src/pages/Swap/AdvancedSwapMode/Trade/Trade.component.tsx
+++ b/src/pages/Swap/AdvancedSwapMode/Trade/Trade.component.tsx
@@ -6,7 +6,7 @@ import styled from 'styled-components'
 
 import { ROUTABLE_PLATFORM_LOGO } from '../../../../constants'
 import { ExternalLink } from '../../../../theme/components'
-import { getExplorerLink } from '../../../../utils'
+import { EXPLORER_LINK_TYPE, getExplorerLink } from '../../../../utils'
 import { AdvancedModeDetailsItems } from '../AdvancedSwapMode.styles'
 import { useStylingTradeBackground } from './Trade.hooks'
 
@@ -51,7 +51,10 @@ export const Trade = ({
   const timestampInMilliseconds = Number(timestamp) * 1000
 
   return (
-    <TradeWrapper style={style} href={getExplorerLink(chainId ?? ChainId.MAINNET, transactionId, 'transaction')}>
+    <TradeWrapper
+      style={style}
+      href={getExplorerLink(chainId ?? ChainId.MAINNET, transactionId, EXPLORER_LINK_TYPE.transaction)}
+    >
       <Flex alignItems="center">
         {ROUTABLE_PLATFORM_LOGO[logoKey]}
         <Text sx={{ marginLeft: '5px' }}>{amountIn}</Text>
@@ -59,7 +62,7 @@ export const Trade = ({
       <Text>{amountOut}</Text>
       {price && <Text>{price}</Text>}
       <Text sx={{ textTransform: 'uppercase', textAlign: 'right', color: '#BCB3F0' }}>
-        {DateTime.fromMillis(timestampInMilliseconds).toFormat('HH:mm')}
+        {DateTime.fromMillis(timestampInMilliseconds).toFormat('HH:mm:ss')}
       </Text>
     </TradeWrapper>
   )

--- a/src/services/AdvancedTradingView/useAdvancedTradingView.hook.ts
+++ b/src/services/AdvancedTradingView/useAdvancedTradingView.hook.ts
@@ -11,7 +11,6 @@ import { useSwapState } from '../../state/swap/hooks'
 import { adapters } from './adapters/adapters.config'
 import { AdvancedTradingViewAdapter } from './adapters/advancedTradingView.adapter'
 import { AdapterAmountToFetch } from './advancedTradingView.types'
-import { actions as advancedTradingViewReducerActions } from './store/advancedTradingView.reducer'
 import { sortsBeforeTokens } from './store/advancedTradingView.selectors'
 
 const WrappedNativeCurrencyAddress = {
@@ -122,12 +121,13 @@ export const useAdvancedTradingView = () => {
 
       advancedTradingViewAdapter.setPairTokens(inputToken, outputToken)
 
+      setSymbol(`${inputToken.symbol}${outputToken.symbol}`)
+
       if (
         // do not fetch data if user reversed pair
         previousTokens.current.inputTokenAddress !== outputToken.address.toLowerCase() ||
         previousTokens.current.outputTokenAddress !== inputToken.address.toLowerCase()
       ) {
-        setSymbol(`${inputToken.symbol}${outputToken.symbol}`)
         setIsLoadingTrades(true)
         setIsLoadingActivity(true)
         setIsFetched(false)
@@ -166,14 +166,6 @@ export const useAdvancedTradingView = () => {
     }
 
     fetchTrades()
-
-    const interval = setInterval(() => {
-      dispatch(advancedTradingViewReducerActions.resetAdapterStore({ resetSelectedPair: false }))
-
-      fetchTrades()
-    }, 15000)
-
-    return () => clearInterval(interval)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     dispatch,

--- a/src/services/AdvancedTradingView/usePairDetails.hook.ts
+++ b/src/services/AdvancedTradingView/usePairDetails.hook.ts
@@ -44,11 +44,18 @@ const calculatePrices = (relativePrice: number, token0Price24h: number, token1Pr
   const priceChange24h = Math.abs(Number(relativePrice.toFixed(6)) - Number(relativePrice24h.toFixed(6))).toFixed(4)
   const priceChange24hWithSymbol = `${Number(priceChange24h) !== 0 ? `${priceChange24h}` : '< 0.0001'}  ${symbol}`
   const percentPriceChange24h = `${(
-    ((Number(relativePrice.toFixed(6)) - Number(relativePrice24h.toFixed(6))) / Number(relativePrice.toFixed(6))) *
+    ((Number(relativePrice) - Number(relativePrice24h)) / Number(relativePrice)) *
     100
   ).toFixed(2)}%`
+  const price =
+    Number(relativePrice.toFixed(10)) !== 0
+      ? Number(relativePrice.toFixed(4)) > 1
+        ? relativePrice.toFixed(4)
+        : relativePrice.toFixed(10)
+      : '< 0.0001'
   const isIncome = relativePrice24h < relativePrice
-  return { priceChange24hWithSymbol, percentPriceChange24h, isIncome }
+
+  return { price, priceChange24hWithSymbol, percentPriceChange24h, isIncome }
 }
 
 export const usePairDetails = (token0?: Token, token1?: Token, activeCurrencyOption?: Token | null) => {
@@ -133,11 +140,11 @@ export const usePairDetails = (token0?: Token, token1?: Token, activeCurrencyOpt
       const relativePrice1 = Number(token1USDPrice.price.toSignificant()) / Number(token0USDPrice.price.toSignificant())
 
       if (token0.address.toLowerCase() === activeCurrencyOption.address.toLowerCase()) {
-        const { priceChange24hWithSymbol, percentPriceChange24h, isIncome } = calculatePrices(
-          relativePrice1,
-          token0USDPrice24h,
+        const { price, priceChange24hWithSymbol, percentPriceChange24h, isIncome } = calculatePrices(
+          relativePrice0,
           token1USDPrice24h,
-          activeCurrencyOption?.symbol ?? ''
+          token0USDPrice24h,
+          token1?.symbol ?? ''
         )
 
         setActiveCurrencyDetails({
@@ -145,19 +152,15 @@ export const usePairDetails = (token0?: Token, token1?: Token, activeCurrencyOpt
           priceChange24h: priceChange24hWithSymbol,
           percentPriceChange24h: percentPriceChange24h,
           isIncome24h: isIncome,
-          volume24h: calculate24hVolumeForActiveCurrencyOption(
-            volume24hUSD,
-            token0USDPrice.price,
-            activeCurrencyOption
-          ),
-          relativePrice: Number(relativePrice0.toFixed(4)) !== 0 ? relativePrice0.toFixed(4) : '< 0.0001',
+          volume24h: calculate24hVolumeForActiveCurrencyOption(volume24hUSD, token1USDPrice.price, token1),
+          relativePrice: price,
         })
       } else {
-        const { priceChange24hWithSymbol, percentPriceChange24h, isIncome } = calculatePrices(
-          relativePrice0,
-          token1USDPrice24h,
+        const { price, priceChange24hWithSymbol, percentPriceChange24h, isIncome } = calculatePrices(
+          relativePrice1,
           token0USDPrice24h,
-          activeCurrencyOption?.symbol ?? ''
+          token1USDPrice24h,
+          token0?.symbol ?? ''
         )
 
         setActiveCurrencyDetails({
@@ -165,12 +168,8 @@ export const usePairDetails = (token0?: Token, token1?: Token, activeCurrencyOpt
           priceChange24h: priceChange24hWithSymbol,
           percentPriceChange24h: percentPriceChange24h,
           isIncome24h: isIncome,
-          volume24h: calculate24hVolumeForActiveCurrencyOption(
-            volume24hUSD,
-            token1USDPrice.price,
-            activeCurrencyOption
-          ),
-          relativePrice: Number(relativePrice1.toFixed(4)) !== 0 ? relativePrice1.toFixed(4) : '< 0.0001',
+          volume24h: calculate24hVolumeForActiveCurrencyOption(volume24hUSD, token0USDPrice.price, token0),
+          relativePrice: price,
         })
       }
     } else {
@@ -196,6 +195,7 @@ export const usePairDetails = (token0?: Token, token1?: Token, activeCurrencyOpt
     token1USDPrice.price,
     token1USDPrice.percentagePriceChange24h,
     token1USDPrice.isIncome24h,
+    token1,
   ])
 
   return {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -51,10 +51,17 @@ const getExplorerPrefix = (chainId: ChainId) => {
   }
 }
 
+export const EXPLORER_LINK_TYPE: Record<string, string> = {
+  transaction: 'transaction',
+  token: 'token',
+  address: 'address',
+  block: 'block',
+}
+
 export function getExplorerLink(
   chainId: ChainId,
   hash: string,
-  type: 'transaction' | 'token' | 'address' | 'block',
+  type: keyof typeof EXPLORER_LINK_TYPE,
   protocol?: string
 ): string {
   //exception with using cow swap. Need to show cow explorer
@@ -66,21 +73,21 @@ export function getExplorerLink(
 
   const prefix = getExplorerPrefix(chainId)
   // exception. blockscout doesn't have a token-specific address
-  if (chainId === ChainId.XDAI && type === 'token') {
+  if (chainId === ChainId.XDAI && type === EXPLORER_LINK_TYPE.token) {
     return `${prefix}/address/${hash}`
   }
 
   switch (type) {
-    case 'transaction': {
+    case EXPLORER_LINK_TYPE.transaction: {
       return `${prefix}/tx/${hash}`
     }
-    case 'token': {
+    case EXPLORER_LINK_TYPE.token: {
       return `${prefix}/token/${hash}`
     }
-    case 'block': {
+    case EXPLORER_LINK_TYPE.block: {
       return `${prefix}/block/${hash}`
     }
-    case 'address':
+    case EXPLORER_LINK_TYPE.address:
     default: {
       return `${prefix}/address/${hash}`
     }


### PR DESCRIPTION
# Summary

Fixes #1584

Improvements to advanced trading view.

  # To Test

1. On advanced trading view
- [ ] Check if trade and activity doesn't load anymore
- [ ] Check if swapping tokens changes pool activity title
- [ ] Link to explorer on order history if it's a swap
- [ ] No link to explorer on order history if it's a bridge swap
- [ ] Trading View chart loading

