### PR TITLE
Fix: pools create/add/remove modal has incorrect width 

### DIFF
--- a/src/pages/AppBody.tsx
+++ b/src/pages/AppBody.tsx
@@ -6,6 +6,7 @@ import { DarkCard } from '../components/Card'
 export const BodyWrapper = styled(DarkCard)<{ tradeDetailsOpen?: boolean }>`
   position: relative;
   min-width: 454px;
+  max-width: 457px;
   width: 100%;
   border-radius: 12px;
   padding: 12px;


### PR DESCRIPTION
# Summary

Add max-width to AppBody to fix full-width on pools add/remove liquidity modal

Fixes #1583

**previous**
<img width="1456" alt="image" src="https://user-images.githubusercontent.com/5664434/202749863-016ae3ec-eb14-431e-a73b-051e66f23c2c.png">
**fixed**
<img width="1069" alt="image" src="https://user-images.githubusercontent.com/5664434/202750322-e5e47b35-0fcf-4d39-be3c-8311cf1f3026.png">


  # To Test

1. Go to pools
- [ ] Choose a pair
- [ ] Click on add liquidity/remove
- [ ] Check the modal has the correct size

2. Go to pools
- [ ] Click on add liquidity
- [ ] Check the modal has the correct size