### PR TITLE
Fix: carrot pill by refactoring getBestApyPairCampaign

### DIFF
--- a/src/utils/liquidityMining.ts
+++ b/src/utils/liquidityMining.ts
@@ -50,13 +50,24 @@ export function getPairRemainingRewardsUSD(pair: Pair, nativeCurrencyUSDPrice: P
 }
 
 export function getBestApyPairCampaign(pair: Pair): LiquidityMiningCampaign | null {
-  // no liquidity mining campaigns check
   if (pair.liquidityMiningCampaigns.length === 0) return null
-  return pair.liquidityMiningCampaigns.reduce((campaign: LiquidityMiningCampaign | null, liquidityMiningCampaign) => {
-    if (!campaign || liquidityMiningCampaign.apy.greaterThan(campaign.apy)) return liquidityMiningCampaign
-    return campaign
+  const now = Math.floor(Date.now() / 1000)
+
+  return pair.liquidityMiningCampaigns.reduce((bestCampaign: LiquidityMiningCampaign | null, currentCampaign) => {
+    const currentCampaignIsOpen = currentCampaign.endsAt && Number(currentCampaign.endsAt) > now
+    const currentCampaignIsLaunched = currentCampaign.startsAt && Number(currentCampaign.startsAt) < now
+    const currentCampaignIsActive = currentCampaignIsOpen && currentCampaignIsLaunched
+
+    if (bestCampaign) {
+      return currentCampaignIsActive && currentCampaign.apy.greaterThan(bestCampaign.apy)
+        ? currentCampaign
+        : bestCampaign
+    } else {
+      return currentCampaignIsActive ? currentCampaign : null
+    }
   }, null)
 }
+
 export function tokenToPricedTokenAmount(
   campaign: any,
   token: Token,


### PR DESCRIPTION
# Summary

Fixes #1579

Refactor `getBestApyPairCampaign` function.
- improve variables names
- only return currentCampaign if the APY is greater. 
- added checks to see if campaign did not launch yet
- Add check to see if campaign is already closed.



<img width="1082" alt="image" src="https://user-images.githubusercontent.com/5664434/202875288-b0a2932f-1878-4bc7-8443-885ad718f622.png">
<img width="173" alt="image" src="https://user-images.githubusercontent.com/5664434/202875290-8e518e7a-5c97-4ec6-8b5a-b13b0cea4b45.png">


  # To Test

1. Go to liquidity pools
- [ ] Check if carrot pill  highlight is correct.

  # Background

*Optional: Give background information for changes you've made, that might be difficult to explain via comments*

