### PR TITLE
Optimisation of Data Dispatching to Redux in Advanced Trading View

### DIFF
--- a/src/services/AdvancedTradingView/adapters/advancedTradingView.adapter.ts
+++ b/src/services/AdvancedTradingView/adapters/advancedTradingView.adapter.ts
@@ -25,6 +25,8 @@ export abstract class AbstractAdvancedTradingViewAdapter<AppState> {
 
   abstract getPairTrades(fetchDetails: AdapterFetchDetails): Promise<void>
 
+  abstract getPairTradesData(fetchDetails: AdapterFetchDetails): any
+
   abstract getPairActivity(fetchDetails: AdapterFetchDetails): Promise<void>
 
   public updateActiveChainId(chainId: ChainId) {
@@ -109,6 +111,7 @@ export class AdvancedTradingViewAdapter<AppState> {
     }
   }
 
+  // UPDATED THIS FUNCTION TO ALTER THE STATE TOGETHER INSTEAD OF DISPATCHING IN CHUNKS
   public async fetchPairTrades(fetchDetails: Omit<AdapterFetchDetails, 'abortController'>) {
     const promises = Object.values(this._adapters).map(adapter =>
       adapter.getPairTrades({ ...fetchDetails, abortController: this.renewAbortController })

--- a/src/services/AdvancedTradingView/adapters/advancedTradingView.adapter.ts
+++ b/src/services/AdvancedTradingView/adapters/advancedTradingView.adapter.ts
@@ -125,20 +125,14 @@ export class AdvancedTradingViewAdapter<AppState> {
       adapter.getPairTradesData({ ...fetchDetails, abortController: this.renewAbortController })
     )
 
-    const response = await Promise.allSettled(promises).then(res => {
-      console.log('RES', res)
+    const response = await Promise.allSettled(promises).then(
+      (res: PromiseSettledResult<{ status: 'fulfilled' | 'rejected'; value: any }>[]) =>
+        res.filter(el => el.status === 'fulfilled' && el.value).map(el => el.status === 'fulfilled' && el.value)
+    )
 
-      // TODO: UPDATE RESPONSE MAPPING!!!
-      return res.map(el => {
-        if (el.status !== 'fulfilled' || !el.value) {
-          return []
-        } else {
-          return el.value
-        }
-      })
-    })
     console.log('PROMISE ARRAY RES', response)
 
+    // @ts-ignore
     this.store.dispatch(this.actions.setSwapsDataForAllPairs(response))
     return response
   }

--- a/src/services/AdvancedTradingView/adapters/advancedTradingView.adapter.ts
+++ b/src/services/AdvancedTradingView/adapters/advancedTradingView.adapter.ts
@@ -149,4 +149,24 @@ export class AdvancedTradingViewAdapter<AppState> {
 
     return await Promise.allSettled(promises)
   }
+
+  public async fetchPairActivityBulkUpdate(fetchDetails: Omit<AdapterFetchDetails, 'abortController'>) {
+    const promises = Object.values(this._adapters).map(adapter =>
+      adapter.getPairData({
+        ...fetchDetails,
+        abortController: this.renewAbortController,
+        dataType: AdapterPayloadType.BURNS_AND_MINTS,
+      })
+    )
+
+    const response = await Promise.allSettled(promises).then(
+      (res: PromiseSettledResult<{ status: 'fulfilled' | 'rejected'; value: any }>[]) =>
+        res.filter(el => el.status === 'fulfilled' && el.value).map(el => el.status === 'fulfilled' && el.value)
+    )
+
+    console.log('PROMISE ARRAY BURNS AND MINTS RES', response)
+
+    // @ts-ignore
+    this.store.dispatch(this.actions.setBurnsAndMintsDataForAllPairs(response))
+  }
 }

--- a/src/services/AdvancedTradingView/adapters/advancedTradingView.adapter.ts
+++ b/src/services/AdvancedTradingView/adapters/advancedTradingView.adapter.ts
@@ -25,6 +25,7 @@ export abstract class AbstractAdvancedTradingViewAdapter<AppState> {
 
   abstract getPairTrades(fetchDetails: AdapterFetchDetails): Promise<void>
 
+  // TODO: UPDATE RES TYPE
   abstract getPairTradesData(fetchDetails: AdapterFetchDetails): any
 
   abstract getPairActivity(fetchDetails: AdapterFetchDetails): Promise<void>

--- a/src/services/AdvancedTradingView/adapters/advancedTradingView.adapter.ts
+++ b/src/services/AdvancedTradingView/adapters/advancedTradingView.adapter.ts
@@ -4,8 +4,10 @@ import { Store } from '@reduxjs/toolkit'
 
 import {
   AdapterFetchDetails,
+  AdapterFetchDetailsExtended,
   AdapterInitialArguments,
   AdapterKey,
+  AdapterPayloadType,
   Adapters,
   AdvancedTradingViewAdapterConstructorParams,
 } from '../advancedTradingView.types'
@@ -26,7 +28,7 @@ export abstract class AbstractAdvancedTradingViewAdapter<AppState> {
   abstract getPairTrades(fetchDetails: AdapterFetchDetails): Promise<void>
 
   // TODO: UPDATE RES TYPE
-  abstract getPairTradesData(fetchDetails: AdapterFetchDetails): any
+  abstract getPairData(fetchDetails: AdapterFetchDetailsExtended): any
 
   abstract getPairActivity(fetchDetails: AdapterFetchDetails): Promise<void>
 
@@ -122,7 +124,11 @@ export class AdvancedTradingViewAdapter<AppState> {
 
   public async fetchPairTradesBulkUpdate(fetchDetails: Omit<AdapterFetchDetails, 'abortController'>) {
     const promises = Object.values(this._adapters).map(adapter =>
-      adapter.getPairTradesData({ ...fetchDetails, abortController: this.renewAbortController })
+      adapter.getPairData({
+        ...fetchDetails,
+        abortController: this.renewAbortController,
+        dataType: AdapterPayloadType.SWAPS,
+      })
     )
 
     const response = await Promise.allSettled(promises).then(
@@ -134,7 +140,6 @@ export class AdvancedTradingViewAdapter<AppState> {
 
     // @ts-ignore
     this.store.dispatch(this.actions.setSwapsDataForAllPairs(response))
-    return response
   }
 
   public async fetchPairActivity(fetchDetails: Omit<AdapterFetchDetails, 'abortController'>) {

--- a/src/services/AdvancedTradingView/adapters/advancedTradingView.adapter.ts
+++ b/src/services/AdvancedTradingView/adapters/advancedTradingView.adapter.ts
@@ -122,6 +122,14 @@ export class AdvancedTradingViewAdapter<AppState> {
     return await Promise.allSettled(promises)
   }
 
+  public async fetchPairActivity(fetchDetails: Omit<AdapterFetchDetails, 'abortController'>) {
+    const promises = Object.values(this._adapters).map(adapter =>
+      adapter.getPairActivity({ ...fetchDetails, abortController: this.renewAbortController })
+    )
+
+    return await Promise.allSettled(promises)
+  }
+
   public async fetchPairTradesBulkUpdate(fetchDetails: Omit<AdapterFetchDetails, 'abortController'>) {
     const promises = Object.values(this._adapters).map(adapter =>
       adapter.getPairData({
@@ -140,14 +148,6 @@ export class AdvancedTradingViewAdapter<AppState> {
 
     // @ts-ignore
     this.store.dispatch(this.actions.setSwapsDataForAllPairs(response))
-  }
-
-  public async fetchPairActivity(fetchDetails: Omit<AdapterFetchDetails, 'abortController'>) {
-    const promises = Object.values(this._adapters).map(adapter =>
-      adapter.getPairActivity({ ...fetchDetails, abortController: this.renewAbortController })
-    )
-
-    return await Promise.allSettled(promises)
   }
 
   public async fetchPairActivityBulkUpdate(fetchDetails: Omit<AdapterFetchDetails, 'abortController'>) {

--- a/src/services/AdvancedTradingView/adapters/advancedTradingView.adapter.ts
+++ b/src/services/AdvancedTradingView/adapters/advancedTradingView.adapter.ts
@@ -144,8 +144,6 @@ export class AdvancedTradingViewAdapter<AppState> {
         res.filter(el => el.status === 'fulfilled' && el.value).map(el => el.status === 'fulfilled' && el.value)
     )
 
-    console.log('PROMISE ARRAY RES', response)
-
     // @ts-ignore
     this.store.dispatch(this.actions.setSwapsDataForAllPairs(response))
   }
@@ -163,8 +161,6 @@ export class AdvancedTradingViewAdapter<AppState> {
       (res: PromiseSettledResult<{ status: 'fulfilled' | 'rejected'; value: any }>[]) =>
         res.filter(el => el.status === 'fulfilled' && el.value).map(el => el.status === 'fulfilled' && el.value)
     )
-
-    console.log('PROMISE ARRAY BURNS AND MINTS RES', response)
 
     // @ts-ignore
     this.store.dispatch(this.actions.setBurnsAndMintsDataForAllPairs(response))

--- a/src/services/AdvancedTradingView/adapters/baseAdapter/base.adapter.ts
+++ b/src/services/AdvancedTradingView/adapters/baseAdapter/base.adapter.ts
@@ -129,6 +129,7 @@ export class BaseAdapter<
     amountToFetch,
     isFirstFetch,
     abortController,
+    refreshing,
   }: AdapterFetchDetailsExtended) {
     if (!this.isSupportedChainId(this._chainId)) return
 
@@ -138,13 +139,14 @@ export class BaseAdapter<
 
     const pair = this.store.getState().advancedTradingView.adapters[this._key][pairId]
 
-    if (
-      (dataType === AdapterPayloadType.SWAPS && pair && !isFirstFetch && !pair.swaps?.hasMore) ||
-      (dataType === AdapterPayloadType.SWAPS && pair && isFirstFetch) ||
-      (dataType === AdapterPayloadType.BURNS_AND_MINTS && pair && !isFirstFetch && !pair.burnsAndMints?.hasMore) ||
-      (dataType === AdapterPayloadType.BURNS_AND_MINTS && pair && isFirstFetch)
-    )
-      return
+    // TODO: CLARIFY THIS WITH ADAM
+    // if (
+    //   (dataType === AdapterPayloadType.SWAPS && pair && !isFirstFetch && !pair.swaps?.hasMore) ||
+    //   (dataType === AdapterPayloadType.SWAPS && pair && isFirstFetch) ||
+    //   (dataType === AdapterPayloadType.BURNS_AND_MINTS && pair && !isFirstFetch && !pair.burnsAndMints?.hasMore) ||
+    //   (dataType === AdapterPayloadType.BURNS_AND_MINTS && pair && isFirstFetch)
+    // )
+    //   return
 
     try {
       if (dataType === AdapterPayloadType.SWAPS) {
@@ -154,6 +156,7 @@ export class BaseAdapter<
           chainId: this._chainId,
           amountToFetch,
           abortController,
+          refreshing,
           inputTokenAddress: inputToken.address,
           outputTokenAddress: outputToken.address,
         })
@@ -173,6 +176,7 @@ export class BaseAdapter<
           chainId: this._chainId,
           amountToFetch,
           abortController,
+          refreshing,
           inputTokenAddress: inputToken.address,
           outputTokenAddress: outputToken.address,
         })
@@ -196,14 +200,21 @@ export class BaseAdapter<
     } catch {}
   }
 
-  protected async _fetchSwaps({ pairId, pair, chainId, amountToFetch, abortController }: AdapterFetchMethodArguments) {
+  protected async _fetchSwaps({
+    pairId,
+    pair,
+    chainId,
+    amountToFetch,
+    abortController,
+    refreshing,
+  }: AdapterFetchMethodArguments) {
     return await request<GenericPairSwaps>({
       url: this._subgraphUrls[chainId],
       document: PAIR_SWAPS,
       variables: {
         pairId,
         first: amountToFetch,
-        skip: pair?.swaps?.data.length ?? 0,
+        skip: refreshing ? 0 : pair?.swaps?.data.length ?? 0,
       },
       signal: abortController(`${this._key}-pair-trades`) as RequestOptions['signal'],
     })
@@ -215,6 +226,7 @@ export class BaseAdapter<
     chainId,
     amountToFetch,
     abortController,
+    refreshing,
   }: AdapterFetchMethodArguments) {
     return await request<GenericPairBurnsAndMints>({
       url: this._subgraphUrls[chainId],
@@ -222,7 +234,7 @@ export class BaseAdapter<
       variables: {
         pairId,
         first: amountToFetch,
-        skip: pair?.burnsAndMints?.data.length ?? 0,
+        skip: refreshing ? 0 : pair?.swaps?.data.length ?? 0,
       },
       signal: abortController(`${this._key}-pair-activity`) as RequestOptions['signal'],
     })

--- a/src/services/AdvancedTradingView/adapters/baseAdapter/base.adapter.ts
+++ b/src/services/AdvancedTradingView/adapters/baseAdapter/base.adapter.ts
@@ -96,20 +96,13 @@ export class BaseAdapter<
   }: AdapterFetchDetails) {
     const pairId = this._getPairId(inputToken, outputToken)
 
-    let data = {
-      key: this._key,
-      pairId,
-      data: [],
-      hasMore: false,
-    }
+    if (!this.isSupportedChainId(this._chainId)) return
 
-    if (!this.isSupportedChainId(this._chainId)) return data
-
-    if (!pairId) return data
+    if (!pairId) return
 
     const pair = this.store.getState().advancedTradingView.adapters[this._key][pairId]
 
-    if ((pair && !isFirstFetch && !pair.swaps?.hasMore) || (pair && isFirstFetch)) return data
+    if ((pair && !isFirstFetch && !pair.swaps?.hasMore) || (pair && isFirstFetch)) return
 
     try {
       const { swaps } = await this._fetchSwaps({
@@ -122,32 +115,15 @@ export class BaseAdapter<
         outputTokenAddress: outputToken.address,
       })
 
-      console.log('RESSSS SWAPS', swaps)
-
-      // @ts-ignore
-      data.data = swaps
-      data.hasMore = swaps.length === amountToFetch
-
-      // this._dispatchSwaps(pairId, swaps, amountToFetch)
-
-      // protected _dispatchSwaps(pairId: string, { swaps }: GenericPairSwaps, amountToFetch: number) {
-      //   const hasMore = swaps.length === amountToFetch
-
-      //   this.store.dispatch(
-      //     this.actions.setPairData({
-      //       key: this._key,
-      //       pairId,
-      //       payloadType: AdapterPayloadType.SWAPS,
-      //       data: swaps,
-      //       hasMore,
-      //     })
-      //   )
-      // }
+      return {
+        key: this._key,
+        pairId,
+        data: swaps,
+        hasMore: swaps.length === amountToFetch,
+      }
     } catch (e) {
       console.warn(`${this._key}${e}`)
-      return data
-    } finally {
-      return data
+      return
     }
   }
 

--- a/src/services/AdvancedTradingView/adapters/baseAdapter/base.adapter.ts
+++ b/src/services/AdvancedTradingView/adapters/baseAdapter/base.adapter.ts
@@ -127,7 +127,6 @@ export class BaseAdapter<
     inputToken,
     outputToken,
     amountToFetch,
-    isFirstFetch,
     abortController,
     refreshing,
   }: AdapterFetchDetailsExtended) {

--- a/src/services/AdvancedTradingView/adapters/baseAdapter/base.adapter.ts
+++ b/src/services/AdvancedTradingView/adapters/baseAdapter/base.adapter.ts
@@ -138,7 +138,13 @@ export class BaseAdapter<
 
     const pair = this.store.getState().advancedTradingView.adapters[this._key][pairId]
 
-    if ((pair && !isFirstFetch && !pair.swaps?.hasMore) || (pair && isFirstFetch)) return
+    if (
+      (dataType === AdapterPayloadType.SWAPS && pair && !isFirstFetch && !pair.swaps?.hasMore) ||
+      (dataType === AdapterPayloadType.SWAPS && pair && isFirstFetch) ||
+      (dataType === AdapterPayloadType.BURNS_AND_MINTS && pair && !isFirstFetch && !pair.burnsAndMints?.hasMore) ||
+      (dataType === AdapterPayloadType.BURNS_AND_MINTS && pair && isFirstFetch)
+    )
+      return
 
     try {
       if (dataType === AdapterPayloadType.SWAPS) {

--- a/src/services/AdvancedTradingView/adapters/baseAdapter/base.types.ts
+++ b/src/services/AdvancedTradingView/adapters/baseAdapter/base.types.ts
@@ -67,6 +67,6 @@ export type SetSwapsActionPayload = {
 }
 
 export type BasePair = {
-  swaps?: { data: PairSwapTransaction[]; hasMore: boolean }
+  swaps?: { data: (PairSwapTransaction | UniswapV3PairSwapTransaction)[]; hasMore: boolean }
   burnsAndMints?: { data: PairBurnsAndMintsTransaction[]; hasMore: boolean }
 }

--- a/src/services/AdvancedTradingView/adapters/baseAdapter/base.types.ts
+++ b/src/services/AdvancedTradingView/adapters/baseAdapter/base.types.ts
@@ -66,6 +66,13 @@ export type SetSwapsActionPayload = {
   data: UniswapV3PairSwapTransaction[]
 }
 
+export type SetBurnsAndMintsActionPayload = {
+  key: AdapterKey
+  hasMore: boolean
+  pairId: string
+  data: PairBurnsAndMintsTransaction[]
+}
+
 export type BasePair = {
   swaps?: { data: (PairSwapTransaction | UniswapV3PairSwapTransaction)[]; hasMore: boolean }
   burnsAndMints?: { data: PairBurnsAndMintsTransaction[]; hasMore: boolean }

--- a/src/services/AdvancedTradingView/adapters/baseAdapter/base.types.ts
+++ b/src/services/AdvancedTradingView/adapters/baseAdapter/base.types.ts
@@ -1,4 +1,5 @@
 import { AdapterKey, AdapterPayloadType } from '../../advancedTradingView.types'
+import { UniswapV3PairSwapTransaction } from '../uniswapV3/uniswapV3.types'
 
 export enum LiquidityTypename {
   BURN = 'Burn',
@@ -56,6 +57,13 @@ export type BaseActionPayload<DataType> = {
   pairId: string
   data: DataType
   payloadType: AdapterPayloadType.SWAPS | AdapterPayloadType.BURNS_AND_MINTS
+}
+
+export type SetSwapsActionPayload = {
+  key: AdapterKey
+  hasMore: boolean
+  pairId: string
+  data: UniswapV3PairSwapTransaction[]
 }
 
 export type BasePair = {

--- a/src/services/AdvancedTradingView/adapters/uniswapV3/uniswapV3.adapter.ts
+++ b/src/services/AdvancedTradingView/adapters/uniswapV3/uniswapV3.adapter.ts
@@ -19,6 +19,7 @@ export class UniswapV3Adapter<
     inputTokenAddress,
     outputTokenAddress,
     pair,
+    refreshing,
   }: AdapterFetchMethodArguments) {
     return await request<GenericPairSwaps>({
       url: this._subgraphUrls[chainId],
@@ -27,7 +28,7 @@ export class UniswapV3Adapter<
         token0_in: [inputTokenAddress.toLowerCase(), outputTokenAddress.toLowerCase()],
         token1_in: [inputTokenAddress.toLowerCase(), outputTokenAddress.toLowerCase()],
         first: amountToFetch,
-        skip: pair?.swaps?.data.length ?? 0,
+        skip: refreshing ? 0 : pair?.swaps?.data.length ?? 0,
       },
       signal: abortController(`${this._key}-pair-trades`) as RequestOptions['signal'],
     })

--- a/src/services/AdvancedTradingView/adapters/uniswapV3/uniswapV3.types.ts
+++ b/src/services/AdvancedTradingView/adapters/uniswapV3/uniswapV3.types.ts
@@ -1,6 +1,6 @@
 import { BaseActionPayload, PairBurnsAndMints, PairBurnsAndMintsTransaction } from '../baseAdapter/base.types'
 
-type UniswapV3PairSwapTransaction = {
+export type UniswapV3PairSwapTransaction = {
   amount0: string
   amount1: string
   amountUSD: string

--- a/src/services/AdvancedTradingView/advancedTradingView.types.ts
+++ b/src/services/AdvancedTradingView/advancedTradingView.types.ts
@@ -75,6 +75,7 @@ export type AdapterFetchDetails = {
   amountToFetch: number
   isFirstFetch: boolean
   abortController: (id: string) => AbortSignal
+  refreshing?: boolean
 }
 
 export type AdapterFetchDetailsExtended = AdapterFetchDetails & { dataType: AdapterPayloadType }
@@ -91,4 +92,5 @@ export type AdapterFetchMethodArguments = Pick<AdapterFetchDetails, 'abortContro
   chainId: ChainId.MAINNET | ChainId.ARBITRUM_ONE | ChainId.GNOSIS | ChainId.POLYGON | ChainId.OPTIMISM_MAINNET
   inputTokenAddress: string
   outputTokenAddress: string
+  refreshing?: boolean
 }

--- a/src/services/AdvancedTradingView/advancedTradingView.types.ts
+++ b/src/services/AdvancedTradingView/advancedTradingView.types.ts
@@ -77,6 +77,8 @@ export type AdapterFetchDetails = {
   abortController: (id: string) => AbortSignal
 }
 
+export type AdapterFetchDetailsExtended = AdapterFetchDetails & { dataType: AdapterPayloadType }
+
 export enum AdapterAmountToFetch {
   PAIR_TRADES = 10,
   PAIR_ACTIVITY = 3,

--- a/src/services/AdvancedTradingView/store/advancedTradingView.reducer.ts
+++ b/src/services/AdvancedTradingView/store/advancedTradingView.reducer.ts
@@ -76,14 +76,14 @@ const advancedTradingViewSlice = createSlice({
       action.payload.forEach(adapter => {
         const { key, pairId, data, hasMore } = adapter
 
-        const previousPairData = state.adapters[key][pairId]?.['burnsAndMints']?.data ?? []
+        const nextPairData = state.adapters[key][pairId]?.['burnsAndMints']?.data ?? []
 
-        data.forEach(element => !previousPairData.some(el => el.id === element.id) && previousPairData.push(element))
+        data.forEach(element => !nextPairData.some(el => el.id === element.id) && nextPairData.push(element))
 
         updatedAdapters[key][pairId] = {
           ...updatedAdapters[key][pairId],
           burnsAndMints: {
-            data: previousPairData,
+            data: nextPairData,
             hasMore,
           },
         }
@@ -101,14 +101,14 @@ const advancedTradingViewSlice = createSlice({
       action.payload.forEach(adapter => {
         const { key, pairId, data, hasMore } = adapter
 
-        const previousPairData = state.adapters[key][pairId]?.['swaps']?.data ?? []
+        const nextPairData = state.adapters[key][pairId]?.['swaps']?.data ?? []
 
-        data.forEach(element => !previousPairData.some(el => el.id === element.id) && previousPairData.push(element))
+        data.forEach(element => !nextPairData.some(el => el.id === element.id) && nextPairData.push(element))
 
         updatedAdapters[key][pairId] = {
           ...updatedAdapters[key][pairId],
           swaps: {
-            data: previousPairData,
+            data: nextPairData,
             hasMore,
           },
         }

--- a/src/services/AdvancedTradingView/store/advancedTradingView.reducer.ts
+++ b/src/services/AdvancedTradingView/store/advancedTradingView.reducer.ts
@@ -38,13 +38,13 @@ const advancedTradingViewSlice = createSlice({
       if (action.payload.resetSelectedPair) {
         state.pair = {}
       }
-      state.adapters = {
-        swapr: {},
-        sushiswap: {},
-        uniswapV2: {},
-        honeyswap: {},
-        uniswapV3: {},
-      }
+      // state.adapters = {
+      //   swapr: {},
+      //   sushiswap: {},
+      //   uniswapV2: {},
+      //   honeyswap: {},
+      //   uniswapV3: {},
+      // }
     },
 
     setPairData: (state, action: PayloadAction<BaseActionPayload<unknown[]>>) => {
@@ -83,12 +83,8 @@ const advancedTradingViewSlice = createSlice({
     setSwapsDataForAllPairs: (state: InitialState, action: PayloadAction<Array<SetSwapsActionPayload>>) => {
       console.log('CURRENT STATE', current(state))
 
-      let updatedAdapters: AdapterType = {
-        swapr: {},
-        sushiswap: {},
-        uniswapV2: {},
-        honeyswap: {},
-        uniswapV3: {},
+      const updatedAdapters = {
+        ...state.adapters,
       }
 
       // TODO: ADD PRESERVE THE OLD ONES FUNCTIONALITY

--- a/src/services/AdvancedTradingView/store/advancedTradingView.reducer.ts
+++ b/src/services/AdvancedTradingView/store/advancedTradingView.reducer.ts
@@ -63,6 +63,8 @@ const advancedTradingViewSlice = createSlice({
     // TODO: UPDATE ACTION TO HANDLE BOTH SWAPS AND ACTIVITY DATA
     // TODO: DEFINE PAYLOAD DATA MODEL
     setSwapsDataForAllPairs: (state: InitialState, action: PayloadAction<Array<BaseActionPayload<unknown[]>>>) => {
+      console.log('ACTION PAYLOAD', action.payload)
+      // [{key: 'uniswapV2', pairId: '0xa478c2975ab1ea89e8196811f51a7b7ade33eb11', data: Array(12), hasMore: true}]
       let updatedAdapters: AdapterType = {
         swapr: {},
         sushiswap: {},

--- a/src/services/AdvancedTradingView/store/advancedTradingView.reducer.ts
+++ b/src/services/AdvancedTradingView/store/advancedTradingView.reducer.ts
@@ -81,19 +81,24 @@ const advancedTradingViewSlice = createSlice({
 
     // TODO: UPDATE ACTION TO HANDLE BOTH SWAPS AND ACTIVITY DATA
     setSwapsDataForAllPairs: (state: InitialState, action: PayloadAction<Array<SetSwapsActionPayload>>) => {
-      console.log('CURRENT STATE', current(state))
-
-      const updatedAdapters = {
+      const updatedAdapters: AdapterType = {
         ...state.adapters,
       }
 
-      // TODO: ADD PRESERVE THE OLD ONES FUNCTIONALITY
+      // TODO: FIX TYPES!
       action.payload.forEach(adapter => {
         const { key, pairId, data, hasMore } = adapter
 
+        // @ts-ignore
+        const previousPairData = state.adapters[key][pairId]?.['swaps']?.data ?? []
+
+        // @ts-ignore
+        data.forEach(element => !previousPairData.some(el => el.id === element.id) && previousPairData.push(element))
+
         updatedAdapters[key][pairId] = {
           swaps: {
-            data,
+            // @ts-ignore
+            data: previousPairData,
             hasMore,
           },
         }

--- a/src/services/AdvancedTradingView/store/advancedTradingView.reducer.ts
+++ b/src/services/AdvancedTradingView/store/advancedTradingView.reducer.ts
@@ -1,9 +1,10 @@
 import { Token } from '@swapr/sdk'
 
-import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+import { createSlice, current, PayloadAction } from '@reduxjs/toolkit'
 
-import { BaseActionPayload } from '../adapters/baseAdapter/base.types'
-import { AdapterPayloadType, AdapterType, InitialState } from '../advancedTradingView.types'
+import { BaseActionPayload, SetSwapsActionPayload } from '../adapters/baseAdapter/base.types'
+import { UniswapV3PairSwapTransaction } from '../adapters/uniswapV3/uniswapV3.types'
+import { AdapterKey, AdapterPayloadType, AdapterType, InitialState } from '../advancedTradingView.types'
 
 export const initialState: InitialState = {
   pair: {
@@ -60,11 +61,28 @@ const advancedTradingViewSlice = createSlice({
       }
     },
 
+    // !!! FINISH THIS
+    setBurnsAndMintsDataForAllPairs: (
+      state: InitialState,
+      action: PayloadAction<
+        Array<
+          BaseActionPayload<
+            {
+              key: AdapterKey
+              pairId: string
+              // TODO: DEFINE DATA MODEL
+              data: any[]
+              hasMore: boolean
+            }[]
+          >
+        >
+      >
+    ) => {},
+
     // TODO: UPDATE ACTION TO HANDLE BOTH SWAPS AND ACTIVITY DATA
-    // TODO: DEFINE PAYLOAD DATA MODEL
-    setSwapsDataForAllPairs: (state: InitialState, action: PayloadAction<Array<BaseActionPayload<unknown[]>>>) => {
-      console.log('ACTION PAYLOAD', action.payload)
-      // [{key: 'uniswapV2', pairId: '0xa478c2975ab1ea89e8196811f51a7b7ade33eb11', data: Array(12), hasMore: true}]
+    setSwapsDataForAllPairs: (state: InitialState, action: PayloadAction<Array<SetSwapsActionPayload>>) => {
+      console.log('CURRENT STATE', current(state))
+
       let updatedAdapters: AdapterType = {
         swapr: {},
         sushiswap: {},
@@ -73,17 +91,13 @@ const advancedTradingViewSlice = createSlice({
         uniswapV3: {},
       }
 
-      // TODO: UPDATED DATA HANDLING OF EACH PAIR
-      action.payload.forEach(pair => {
-        const { data, pairId, hasMore, key } = pair
-
-        const previousPairData = state.adapters[key][pairId]?.[AdapterPayloadType.SWAPS]?.data ?? []
+      // TODO: ADD PRESERVE THE OLD ONES FUNCTIONALITY
+      action.payload.forEach(adapter => {
+        const { key, pairId, data, hasMore } = adapter
 
         updatedAdapters[key][pairId] = {
-          ...state.adapters[key][pairId],
           swaps: {
-            // @ts-ignore
-            data: [...previousPairData, ...data],
+            data,
             hasMore,
           },
         }

--- a/src/services/AdvancedTradingView/store/advancedTradingView.reducer.ts
+++ b/src/services/AdvancedTradingView/store/advancedTradingView.reducer.ts
@@ -85,19 +85,15 @@ const advancedTradingViewSlice = createSlice({
         ...state.adapters,
       }
 
-      // TODO: FIX TYPES!
       action.payload.forEach(adapter => {
         const { key, pairId, data, hasMore } = adapter
 
-        // @ts-ignore
         const previousPairData = state.adapters[key][pairId]?.['swaps']?.data ?? []
 
-        // @ts-ignore
         data.forEach(element => !previousPairData.some(el => el.id === element.id) && previousPairData.push(element))
 
         updatedAdapters[key][pairId] = {
           swaps: {
-            // @ts-ignore
             data: previousPairData,
             hasMore,
           },

--- a/src/services/AdvancedTradingView/store/advancedTradingView.reducer.ts
+++ b/src/services/AdvancedTradingView/store/advancedTradingView.reducer.ts
@@ -3,7 +3,7 @@ import { Token } from '@swapr/sdk'
 import { createSlice, PayloadAction } from '@reduxjs/toolkit'
 
 import { BaseActionPayload } from '../adapters/baseAdapter/base.types'
-import { InitialState } from '../advancedTradingView.types'
+import { AdapterPayloadType, AdapterType, InitialState } from '../advancedTradingView.types'
 
 export const initialState: InitialState = {
   pair: {
@@ -32,6 +32,7 @@ const advancedTradingViewSlice = createSlice({
         outputToken,
       }
     },
+
     resetAdapterStore: (state, action: PayloadAction<{ resetSelectedPair: boolean }>) => {
       if (action.payload.resetSelectedPair) {
         state.pair = {}
@@ -57,6 +58,35 @@ const advancedTradingViewSlice = createSlice({
           hasMore,
         },
       }
+    },
+
+    // TODO: UPDATE ACTION TO HANDLE BOTH SWAPS AND ACTIVITY DATA
+    setSwapsDataForAllPairs: (state: InitialState, action: PayloadAction<Array<BaseActionPayload<unknown[]>>>) => {
+      let updatedAdapters: AdapterType = {
+        swapr: {},
+        sushiswap: {},
+        uniswapV2: {},
+        honeyswap: {},
+        uniswapV3: {},
+      }
+
+      // TODO: UPDATED DATA HANDLING OF EACH PAIR
+      action.payload.forEach(pair => {
+        const { data, pairId, hasMore, key } = pair
+
+        const previousPairData = state.adapters[key][pairId]?.[AdapterPayloadType.SWAPS]?.data ?? []
+
+        updatedAdapters[key][pairId] = {
+          ...state.adapters[key][pairId],
+          swaps: {
+            // @ts-ignore
+            data: [...previousPairData, ...data],
+            hasMore,
+          },
+        }
+      })
+
+      state.adapters = updatedAdapters
     },
   },
 })

--- a/src/services/AdvancedTradingView/store/advancedTradingView.reducer.ts
+++ b/src/services/AdvancedTradingView/store/advancedTradingView.reducer.ts
@@ -1,14 +1,13 @@
 import { Token } from '@swapr/sdk'
 
-import { createSlice, current, PayloadAction } from '@reduxjs/toolkit'
+import { createSlice, PayloadAction } from '@reduxjs/toolkit'
 
 import {
   BaseActionPayload,
   SetBurnsAndMintsActionPayload,
   SetSwapsActionPayload,
 } from '../adapters/baseAdapter/base.types'
-import { UniswapV3PairSwapTransaction } from '../adapters/uniswapV3/uniswapV3.types'
-import { AdapterKey, AdapterPayloadType, AdapterType, InitialState } from '../advancedTradingView.types'
+import { AdapterType, InitialState } from '../advancedTradingView.types'
 
 export const initialState: InitialState = {
   pair: {

--- a/src/services/AdvancedTradingView/store/advancedTradingView.reducer.ts
+++ b/src/services/AdvancedTradingView/store/advancedTradingView.reducer.ts
@@ -61,6 +61,7 @@ const advancedTradingViewSlice = createSlice({
     },
 
     // TODO: UPDATE ACTION TO HANDLE BOTH SWAPS AND ACTIVITY DATA
+    // TODO: DEFINE PAYLOAD DATA MODEL
     setSwapsDataForAllPairs: (state: InitialState, action: PayloadAction<Array<BaseActionPayload<unknown[]>>>) => {
       let updatedAdapters: AdapterType = {
         swapr: {},

--- a/src/services/AdvancedTradingView/store/advancedTradingView.selectors.ts
+++ b/src/services/AdvancedTradingView/store/advancedTradingView.selectors.ts
@@ -78,6 +78,7 @@ const selectAllCurrentPairs = createSelector(
     pairs.reduce<AllTradesAndLiquidityFromAdapters>(
       (dataFromAllAdapters, adapterPair) => {
         if (adapterPair?.pair?.swaps) {
+          // @ts-ignore
           dataFromAllAdapters.swaps = [
             ...dataFromAllAdapters.swaps,
             ...adapterPair.pair.swaps.data.map(tx => ({ ...tx, logoKey: adapterPair.logoKey })),

--- a/src/services/AdvancedTradingView/useAdvancedTradingView.hook.ts
+++ b/src/services/AdvancedTradingView/useAdvancedTradingView.hook.ts
@@ -70,8 +70,8 @@ export const useAdvancedTradingView = () => {
     outputTokenAddress: undefined,
   })
 
-  const [isLoadingTrades, setIsLoadingTrades] = useState(false)
-  const [isLoadingActivity, setIsLoadingActivity] = useState(false)
+  const [isLoadingTrades, setIsLoadingTrades] = useState(true)
+  const [isLoadingActivity, setIsLoadingActivity] = useState(true)
   const [isFetched, setIsFetched] = useState(false)
 
   const dispatch = useDispatch()

--- a/src/services/AdvancedTradingView/useAdvancedTradingView.hook.ts
+++ b/src/services/AdvancedTradingView/useAdvancedTradingView.hook.ts
@@ -139,12 +139,14 @@ export const useAdvancedTradingView = () => {
               outputToken,
               amountToFetch: pairTradesAmountToFetch,
               isFirstFetch: true,
+              refreshing: true,
             }),
             advancedTradingViewAdapter.fetchPairActivityBulkUpdate({
               inputToken,
               outputToken,
               amountToFetch: pairActivityAmountToFetch,
               isFirstFetch: true,
+              refreshing: true,
             }),
           ])
         } catch (e) {

--- a/src/services/AdvancedTradingView/useAdvancedTradingView.hook.ts
+++ b/src/services/AdvancedTradingView/useAdvancedTradingView.hook.ts
@@ -128,19 +128,19 @@ export const useAdvancedTradingView = () => {
         previousTokens.current.outputTokenAddress !== inputToken.address.toLowerCase()
       ) {
         setSymbol(`${inputToken.symbol}${outputToken.symbol}`)
-        setIsLoadingTrades(true)
+        setIsLoadingTrades(false)
         setIsLoadingActivity(true)
         setIsFetched(false)
 
         try {
           await Promise.allSettled([
-            advancedTradingViewAdapter.fetchPairTrades({
+            advancedTradingViewAdapter.fetchPairTradesBulkUpdate({
               inputToken,
               outputToken,
               amountToFetch: pairTradesAmountToFetch,
               isFirstFetch: true,
             }),
-            advancedTradingViewAdapter.fetchPairActivity({
+            advancedTradingViewAdapter.fetchPairActivityBulkUpdate({
               inputToken,
               outputToken,
               amountToFetch: pairActivityAmountToFetch,
@@ -201,7 +201,7 @@ export const useAdvancedTradingView = () => {
 
     setIsLoadingTrades(true)
     try {
-      await advancedTradingViewAdapter.fetchPairTrades({
+      await advancedTradingViewAdapter.fetchPairTradesBulkUpdate({
         inputToken,
         outputToken,
         amountToFetch: AdapterAmountToFetch.PAIR_TRADES,
@@ -219,7 +219,7 @@ export const useAdvancedTradingView = () => {
 
     setIsLoadingActivity(true)
     try {
-      await advancedTradingViewAdapter.fetchPairActivity({
+      await advancedTradingViewAdapter.fetchPairActivityBulkUpdate({
         inputToken,
         outputToken,
         amountToFetch: AdapterAmountToFetch.PAIR_ACTIVITY,


### PR DESCRIPTION
# Background

Resolves #1587.

I detected an issue with our current way of handling data in `Advanced Trading View`. Every 15 seconds, we are reaching out for the latest data in order to populate the page with fresh data.

I've noticed next logical and optimisation issues:
- same part of the state is being updated with same type of data in multiple chunks at the same time
- adapters state in **Advanced Trading View**'s state slice is being reseted every 15 seconds
- we are presenting fetching state in `Trades` component for the background updates
- there is way to differentiate background update calls which get the latest data from the calls which get an older data.

# Updates

Next is done:
- updated fetching the data methods both for trades and burns & mints
- created **Redux** actions which update the state with bulks of data
- updated data models and added missing ones
- updated logic of `useAdvancedTradingView` hook.

# In the Future

Going forward there are few more things considering this part of the application that might be done as an improvement:
- explore the options to fetch swaps and burns & mints data with same the API calls
- created **Redux** actions which will handle both swaps and burns & mints data together
- remove excess code from the codebase
- organise components and logic in smaller, more readable and maintainable entities
- write the documentation about the logic for `Advanced Trading View`.
