### PR TITLE
Optimisation of Data Fetching in Advanced Trading View

### DIFF
--- a/src/services/AdvancedTradingView/adapters/adapters.config.ts
+++ b/src/services/AdvancedTradingView/adapters/adapters.config.ts
@@ -3,12 +3,16 @@ import { ChainId, UniswapV2RoutablePlatform } from '@swapr/sdk'
 import { AppState } from '../../../state'
 import { AdapterKey, Adapters } from '../advancedTradingView.types'
 import { BaseAdapter } from './baseAdapter/base.adapter'
-import { PairBurnsAndMints, PairSwaps } from './baseAdapter/base.types'
+import { PairBurnsAndMints, PairSwaps, PairSwapsBurnsAndMints } from './baseAdapter/base.types'
 import { UniswapV3Adapter } from './uniswapV3/uniswapV3.adapter'
-import { UniswapV3PairBurnsAndMints, UniswapV3PairSwaps } from './uniswapV3/uniswapV3.types'
+import {
+  UniswapV3PairBurnsAndMints,
+  UniswapV3PairSwaps,
+  UniswapV3SwapsBurnsAndMints,
+} from './uniswapV3/uniswapV3.types'
 
 export const adapters: Adapters<AppState> = {
-  swapr: new BaseAdapter<AppState, PairSwaps, PairBurnsAndMints>({
+  swapr: new BaseAdapter<AppState, PairSwapsBurnsAndMints, PairSwaps, PairBurnsAndMints>({
     key: AdapterKey.SWAPR,
     adapterSupportedChains: [ChainId.MAINNET, ChainId.ARBITRUM_ONE, ChainId.GNOSIS],
     platform: UniswapV2RoutablePlatform.SWAPR,
@@ -20,7 +24,7 @@ export const adapters: Adapters<AppState> = {
       [ChainId.OPTIMISM_MAINNET]: '',
     },
   }),
-  sushiswap: new BaseAdapter<AppState, PairSwaps, PairBurnsAndMints>({
+  sushiswap: new BaseAdapter<AppState, PairSwapsBurnsAndMints, PairSwaps, PairBurnsAndMints>({
     key: AdapterKey.SUSHISWAP,
     adapterSupportedChains: [ChainId.MAINNET, ChainId.ARBITRUM_ONE, ChainId.GNOSIS],
     platform: UniswapV2RoutablePlatform.SUSHISWAP,
@@ -32,7 +36,7 @@ export const adapters: Adapters<AppState> = {
       [ChainId.OPTIMISM_MAINNET]: '',
     },
   }),
-  uniswapV2: new BaseAdapter<AppState, PairSwaps, PairBurnsAndMints>({
+  uniswapV2: new BaseAdapter<AppState, PairSwapsBurnsAndMints, PairSwaps, PairBurnsAndMints>({
     key: AdapterKey.UNISWAPV2,
     adapterSupportedChains: [ChainId.MAINNET],
     platform: UniswapV2RoutablePlatform.UNISWAP,
@@ -44,7 +48,7 @@ export const adapters: Adapters<AppState> = {
       [ChainId.OPTIMISM_MAINNET]: '',
     },
   }),
-  honeyswap: new BaseAdapter<AppState, PairSwaps, PairBurnsAndMints>({
+  honeyswap: new BaseAdapter<AppState, PairSwapsBurnsAndMints, PairSwaps, PairBurnsAndMints>({
     key: AdapterKey.HONEYSWAP,
     adapterSupportedChains: [ChainId.GNOSIS],
     platform: UniswapV2RoutablePlatform.HONEYSWAP,
@@ -56,7 +60,12 @@ export const adapters: Adapters<AppState> = {
       [ChainId.OPTIMISM_MAINNET]: '',
     },
   }),
-  uniswapV3: new UniswapV3Adapter<AppState, UniswapV3PairSwaps, UniswapV3PairBurnsAndMints>({
+  uniswapV3: new UniswapV3Adapter<
+    AppState,
+    UniswapV3SwapsBurnsAndMints,
+    UniswapV3PairSwaps,
+    UniswapV3PairBurnsAndMints
+  >({
     key: AdapterKey.UNISWAPV3,
     adapterSupportedChains: [ChainId.MAINNET, ChainId.ARBITRUM_ONE, ChainId.POLYGON, ChainId.OPTIMISM_MAINNET],
     subgraphUrls: {

--- a/src/services/AdvancedTradingView/adapters/baseAdapter/base.adapter.test.ts
+++ b/src/services/AdvancedTradingView/adapters/baseAdapter/base.adapter.test.ts
@@ -7,7 +7,7 @@ import { AdapterKey } from '../../advancedTradingView.types'
 import advancedTradingView, { actions } from '../../store/advancedTradingView.reducer'
 import { selectCurrentSwaprPair } from '../../store/advancedTradingView.selectors'
 import { BaseAdapter, BaseAppState } from './base.adapter'
-import { PairBurnsAndMints, PairSwaps } from './base.types'
+import { PairBurnsAndMints, PairSwaps, PairSwapsBurnsAndMints } from './base.types'
 
 const FAKE_SWAP_DATA = {
   id: '1',
@@ -42,7 +42,7 @@ const graphqlRequestMock = graphqlRequest as jest.Mock
 
 describe('BaseAdapter', () => {
   let store: Store<BaseAppState>
-  let baseAdapter: BaseAdapter<BaseAppState, PairSwaps, PairBurnsAndMints>
+  let baseAdapter: BaseAdapter<BaseAppState, PairSwapsBurnsAndMints, PairSwaps, PairBurnsAndMints>
 
   beforeEach(() => {
     store = configureStore({

--- a/src/services/AdvancedTradingView/adapters/baseAdapter/base.adapter.ts
+++ b/src/services/AdvancedTradingView/adapters/baseAdapter/base.adapter.ts
@@ -11,7 +11,7 @@ import {
 } from '../../advancedTradingView.types'
 import { initialState as advancedTradingViewInitialState } from '../../store/advancedTradingView.reducer'
 import { AbstractAdvancedTradingViewAdapter } from '../advancedTradingView.adapter'
-import { PAIR_BURNS_AND_MINTS, PAIR_SWAPS } from './base.queries'
+import { PAIR_BURNS_AND_MINTS, PAIR_SWAPS, PAIR_SWAPS_BURNS_AND_MINTS } from './base.queries'
 
 export interface BaseAppState {
   advancedTradingView: typeof advancedTradingViewInitialState
@@ -19,6 +19,7 @@ export interface BaseAppState {
 
 export class BaseAdapter<
   AppState extends BaseAppState,
+  GenericPairSwapsBurnsAndMints extends { swaps: unknown[]; burns: unknown[]; mints: unknown[] },
   GenericPairSwaps extends { swaps: unknown[] },
   GenericPairBurnsAndMints extends { burns: unknown[]; mints: unknown[] }
 > extends AbstractAdvancedTradingViewAdapter<AppState> {
@@ -197,6 +198,23 @@ export class BaseAdapter<
     try {
       return Pair.getAddress(inputToken, outputToken, this._platform).toLowerCase()
     } catch {}
+  }
+
+  protected async _fetchSwapsBurnsAndMints({
+    pairId,
+    chainId,
+    amountToFetch,
+    abortController,
+  }: AdapterFetchMethodArguments) {
+    return await request<GenericPairSwapsBurnsAndMints>({
+      url: this._subgraphUrls[chainId],
+      document: PAIR_SWAPS_BURNS_AND_MINTS,
+      variables: {
+        pairId,
+        first: amountToFetch,
+      },
+      signal: abortController(`${this._key}-pair-trades`) as RequestOptions['signal'],
+    })
   }
 
   protected async _fetchSwaps({

--- a/src/services/AdvancedTradingView/adapters/baseAdapter/base.adapter.ts
+++ b/src/services/AdvancedTradingView/adapters/baseAdapter/base.adapter.ts
@@ -157,7 +157,13 @@ export class BaseAdapter<
       return {
         key: this._key,
         pairId,
-        data: [...mints, ...burns, ...mints],
+        data: {
+          swaps,
+          burnsAndMints: [...burns, ...mints],
+        },
+        hasMore: Boolean(
+          swaps.length === amountToFetch || burns.length === amountToFetch || mints.length === amountToFetch
+        ),
       }
     } catch (e) {
       console.warn(`${this._key}${e}`)

--- a/src/services/AdvancedTradingView/adapters/baseAdapter/base.adapter.ts
+++ b/src/services/AdvancedTradingView/adapters/baseAdapter/base.adapter.ts
@@ -123,6 +123,48 @@ export class BaseAdapter<
     }
   }
 
+  public async getPairTradingAndActivityData({
+    inputToken,
+    outputToken,
+    amountToFetch,
+    abortController,
+    refreshing,
+  }: AdapterFetchDetails) {
+    if (!this.isSupportedChainId(this._chainId)) return
+
+    const pairId = this._getPairId(inputToken, outputToken)
+
+    if (!pairId) return
+
+    const pair = this.store.getState().advancedTradingView.adapters[this._key][pairId]
+
+    try {
+      const { swaps, burns, mints } = await this._fetchSwapsBurnsAndMints({
+        pairId,
+        pair,
+        chainId: this._chainId,
+        amountToFetch,
+        abortController,
+        refreshing,
+        inputTokenAddress: inputToken.address,
+        outputTokenAddress: outputToken.address,
+      })
+
+      console.log('swaps', swaps)
+      console.log('burns', burns)
+      console.log('mints', mints)
+
+      return {
+        key: this._key,
+        pairId,
+        data: [...mints, ...burns, ...mints],
+      }
+    } catch (e) {
+      console.warn(`${this._key}${e}`)
+      return
+    }
+  }
+
   public async getPairData({
     dataType,
     inputToken,

--- a/src/services/AdvancedTradingView/adapters/baseAdapter/base.queries.ts
+++ b/src/services/AdvancedTradingView/adapters/baseAdapter/base.queries.ts
@@ -2,6 +2,31 @@ import { gql } from 'graphql-request'
 
 import { BASE_QUERY_FRAGMENT } from '../fragment.queries'
 
+export const PAIR_SWAPS_BURNS_AND_MINTS = gql`
+  query getPairTradesAndActivity($pairId: Bytes!, $first: Int!, $skip: Int!) {
+    swaps(where: { pair: $pairId }, first: $first, skip: $skip, orderDirection: "desc", orderBy: "timestamp") {
+      id
+      transaction {
+        id
+      }
+      amount0In
+      amount1In
+      amount0Out
+      amount1Out
+      amountUSD
+      timestamp
+    }
+    mints(where: { pair: $pairId }, first: $first, skip: $skip, orderDirection: "desc", orderBy: "timestamp") {
+     ${BASE_QUERY_FRAGMENT}
+      type: __typename
+    }
+    burns(where: { pair: $pairId }, first: $first, skip: $skip, orderDirection: "desc", orderBy: "timestamp") {
+     ${BASE_QUERY_FRAGMENT}
+      type: __typename
+    }
+  }
+`
+
 export const PAIR_SWAPS = gql`
   query getPairTrades($pairId: Bytes!, $first: Int!, $skip: Int!) {
     swaps(where: { pair: $pairId }, first: $first, skip: $skip, orderDirection: "desc", orderBy: "timestamp") {

--- a/src/services/AdvancedTradingView/adapters/baseAdapter/base.queries.ts
+++ b/src/services/AdvancedTradingView/adapters/baseAdapter/base.queries.ts
@@ -3,7 +3,7 @@ import { gql } from 'graphql-request'
 import { BASE_QUERY_FRAGMENT } from '../fragment.queries'
 
 export const PAIR_SWAPS_BURNS_AND_MINTS = gql`
-  query getPairTradesAndActivity($pairId: Bytes!, $first: Int!, $skip: Int!) {
+  query getPairTradesAndActivity($pairId: Bytes!, $first: Int!) {
     swaps(where: { pair: $pairId }, first: $first, skip: $skip, orderDirection: "desc", orderBy: "timestamp") {
       id
       transaction {

--- a/src/services/AdvancedTradingView/adapters/baseAdapter/base.types.ts
+++ b/src/services/AdvancedTradingView/adapters/baseAdapter/base.types.ts
@@ -42,6 +42,12 @@ export type AllTradesAndLiquidityFromAdapters = {
   burnsAndMints: BurnsAndMintsWithLogo[]
 }
 
+export type PairSwapsBurnsAndMints = {
+  swaps: PairSwapTransaction[]
+  burns: PairBurnsAndMintsTransaction[]
+  mints: PairBurnsAndMintsTransaction[]
+}
+
 export type PairSwaps = {
   swaps: PairSwapTransaction[]
 }

--- a/src/services/AdvancedTradingView/adapters/baseAdapter/base.types.ts
+++ b/src/services/AdvancedTradingView/adapters/baseAdapter/base.types.ts
@@ -65,6 +65,16 @@ export type BaseActionPayload<DataType> = {
   payloadType: AdapterPayloadType.SWAPS | AdapterPayloadType.BURNS_AND_MINTS
 }
 
+export type SetSwapsBurnsAndMintsActionPayload = {
+  key: AdapterKey
+  hasMore: boolean
+  pairId: string
+  data: {
+    swaps: UniswapV3PairSwapTransaction[]
+    burnsAndMints: PairBurnsAndMintsTransaction[]
+  }
+}
+
 export type SetSwapsActionPayload = {
   key: AdapterKey
   hasMore: boolean

--- a/src/services/AdvancedTradingView/adapters/uniswapV3/uniswapV3.adapter.ts
+++ b/src/services/AdvancedTradingView/adapters/uniswapV3/uniswapV3.adapter.ts
@@ -5,13 +5,37 @@ import { request, RequestOptions } from 'graphql-request'
 import { AdapterFetchMethodArguments } from '../../advancedTradingView.types'
 import { sortsBeforeTokens } from '../../store/advancedTradingView.selectors'
 import { BaseAdapter, BaseAppState } from '../baseAdapter/base.adapter'
-import { UNISWAP_PAIR_BURNS_AND_MINTS, UNISWAP_PAIR_SWAPS } from './uniswapV3.queries'
+import {
+  UNISWAP_PAIR_BURNS_AND_MINTS,
+  UNISWAP_PAIR_SWAPS,
+  UNISWAP_PAIR_SWAPS_BURNS_AND_MINTS,
+} from './uniswapV3.queries'
 
 export class UniswapV3Adapter<
   AppState extends BaseAppState,
+  GenericPairSwapsBurnsAndMints extends { swaps: unknown[]; burns: unknown[]; mints: unknown[] },
   GenericPairSwaps extends { swaps: unknown[] },
   GenericPairBurnsAndMints extends { burns: unknown[]; mints: unknown[] }
-> extends BaseAdapter<AppState, GenericPairSwaps, GenericPairBurnsAndMints> {
+> extends BaseAdapter<AppState, GenericPairSwapsBurnsAndMints, GenericPairSwaps, GenericPairBurnsAndMints> {
+  protected async _fetchSwapsBurnsAndMints({
+    abortController,
+    amountToFetch,
+    chainId,
+    inputTokenAddress,
+    outputTokenAddress,
+  }: AdapterFetchMethodArguments) {
+    return await request<GenericPairSwapsBurnsAndMints>({
+      url: this._subgraphUrls[chainId],
+      document: UNISWAP_PAIR_SWAPS_BURNS_AND_MINTS,
+      variables: {
+        token0_in: [inputTokenAddress.toLowerCase(), outputTokenAddress.toLowerCase()],
+        token1_in: [inputTokenAddress.toLowerCase(), outputTokenAddress.toLowerCase()],
+        first: amountToFetch,
+      },
+      signal: abortController(`${this._key}-pair-trades`) as RequestOptions['signal'],
+    })
+  }
+
   protected async _fetchSwaps({
     abortController,
     amountToFetch,

--- a/src/services/AdvancedTradingView/adapters/uniswapV3/uniswapV3.queries.ts
+++ b/src/services/AdvancedTradingView/adapters/uniswapV3/uniswapV3.queries.ts
@@ -3,11 +3,10 @@ import { gql } from 'graphql-request'
 import { BASE_QUERY_FRAGMENT } from '../fragment.queries'
 
 export const UNISWAP_PAIR_SWAPS_BURNS_AND_MINTS = gql`
-  query getPairTradesAndActivity($token0_in: [Bytes]!, $token1_in: [Bytes]!, $first: Int!, $skip: Int!) {
+  query getPairTradesAndActivity($token0_in: [Bytes]!, $token1_in: [Bytes]!, $first: Int!) {
     swaps(
       where: { token0_in: $token0_in, token1_in: $token1_in }
       first: $first
-      skip: $skip
       orderDirection: "desc"
       orderBy: "timestamp"
     ) {
@@ -23,7 +22,6 @@ export const UNISWAP_PAIR_SWAPS_BURNS_AND_MINTS = gql`
     mints(
       where: { token0_in: $token0_in, token1_in: $token1_in }
       first: $first
-      skip: $skip
       orderDirection: "desc"
       orderBy: "timestamp"
     ) {
@@ -33,7 +31,6 @@ export const UNISWAP_PAIR_SWAPS_BURNS_AND_MINTS = gql`
     burns(
       where: { token0_in: $token0_in, token1_in: $token1_in }
       first: $first
-      skip: $skip
       orderDirection: "desc"
       orderBy: "timestamp"
     ) {

--- a/src/services/AdvancedTradingView/adapters/uniswapV3/uniswapV3.queries.ts
+++ b/src/services/AdvancedTradingView/adapters/uniswapV3/uniswapV3.queries.ts
@@ -2,6 +2,47 @@ import { gql } from 'graphql-request'
 
 import { BASE_QUERY_FRAGMENT } from '../fragment.queries'
 
+export const UNISWAP_PAIR_SWAPS_BURNS_AND_MINTS = gql`
+  query getPairTradesAndActivity($token0_in: [Bytes]!, $token1_in: [Bytes]!, $first: Int!, $skip: Int!) {
+    swaps(
+      where: { token0_in: $token0_in, token1_in: $token1_in }
+      first: $first
+      skip: $skip
+      orderDirection: "desc"
+      orderBy: "timestamp"
+    ) {
+      id
+      transaction {
+        id
+      }
+      amount1
+      amount0
+      amountUSD
+      timestamp
+    }
+    mints(
+      where: { token0_in: $token0_in, token1_in: $token1_in }
+      first: $first
+      skip: $skip
+      orderDirection: "desc"
+      orderBy: "timestamp"
+    ) {
+     ${BASE_QUERY_FRAGMENT}
+      type: __typename
+    }
+    burns(
+      where: { token0_in: $token0_in, token1_in: $token1_in }
+      first: $first
+      skip: $skip
+      orderDirection: "desc"
+      orderBy: "timestamp"
+    ) {
+     ${BASE_QUERY_FRAGMENT}
+      type: __typename
+    }
+  }
+`
+
 export const UNISWAP_PAIR_SWAPS = gql`
   query getPairTrades($token0_in: [Bytes]!, $token1_in: [Bytes]!, $first: Int!, $skip: Int!) {
     swaps(

--- a/src/services/AdvancedTradingView/adapters/uniswapV3/uniswapV3.types.ts
+++ b/src/services/AdvancedTradingView/adapters/uniswapV3/uniswapV3.types.ts
@@ -22,6 +22,12 @@ export type AllTradesAndLiquidityFromUniswapV3Adapters = {
   burnsAndMints: BurnsAndMintsWithLogo[]
 }
 
+export type UniswapV3SwapsBurnsAndMints = {
+  swaps: UniswapV3PairSwapTransaction[]
+  burns: PairBurnsAndMintsTransaction[]
+  mints: PairBurnsAndMintsTransaction[]
+}
+
 export type UniswapV3PairSwaps = {
   swaps: UniswapV3PairSwapTransaction[]
 }

--- a/src/services/AdvancedTradingView/advancedTradingView.types.ts
+++ b/src/services/AdvancedTradingView/advancedTradingView.types.ts
@@ -88,7 +88,7 @@ export enum AdapterAmountToFetch {
 
 export type AdapterFetchMethodArguments = Pick<AdapterFetchDetails, 'abortController' | 'amountToFetch'> & {
   pairId: string
-  pair?: BasePair | UniswapV3Pair | undefined
+  pair?: BasePair | UniswapV3Pair
   chainId: ChainId.MAINNET | ChainId.ARBITRUM_ONE | ChainId.GNOSIS | ChainId.POLYGON | ChainId.OPTIMISM_MAINNET
   inputTokenAddress: string
   outputTokenAddress: string

--- a/src/services/AdvancedTradingView/advancedTradingView.types.ts
+++ b/src/services/AdvancedTradingView/advancedTradingView.types.ts
@@ -73,7 +73,7 @@ export type AdapterFetchDetails = {
   inputToken: Token
   outputToken: Token
   amountToFetch: number
-  isFirstFetch: boolean
+  isFirstFetch?: boolean
   abortController: (id: string) => AbortSignal
   refreshing?: boolean
 }
@@ -88,7 +88,7 @@ export enum AdapterAmountToFetch {
 
 export type AdapterFetchMethodArguments = Pick<AdapterFetchDetails, 'abortController' | 'amountToFetch'> & {
   pairId: string
-  pair: BasePair | UniswapV3Pair | undefined
+  pair?: BasePair | UniswapV3Pair | undefined
   chainId: ChainId.MAINNET | ChainId.ARBITRUM_ONE | ChainId.GNOSIS | ChainId.POLYGON | ChainId.OPTIMISM_MAINNET
   inputTokenAddress: string
   outputTokenAddress: string

--- a/src/services/AdvancedTradingView/store/advancedTradingView.reducer.ts
+++ b/src/services/AdvancedTradingView/store/advancedTradingView.reducer.ts
@@ -6,6 +6,7 @@ import {
   BaseActionPayload,
   SetBurnsAndMintsActionPayload,
   SetSwapsActionPayload,
+  SetSwapsBurnsAndMintsActionPayload,
 } from '../adapters/baseAdapter/base.types'
 import { AdapterType, InitialState } from '../advancedTradingView.types'
 
@@ -62,6 +63,44 @@ const advancedTradingViewSlice = createSlice({
           hasMore,
         },
       }
+    },
+
+    setSwapsBurnsAndMintsDataForAllPairs: (
+      state: InitialState,
+      action: PayloadAction<Array<SetSwapsBurnsAndMintsActionPayload>>
+    ) => {
+      const updatedAdapters: AdapterType = {
+        ...state.adapters,
+      }
+
+      action.payload.forEach(adapter => {
+        const { key, pairId, data, hasMore } = adapter
+
+        const nextPairSwapData = state.adapters[key][pairId]?.['swaps']?.data ?? []
+        const nextPairBurnsAndMintsData = state.adapters[key][pairId]?.['burnsAndMints']?.data ?? []
+
+        data.swaps.forEach(
+          element => !nextPairSwapData.some(el => el.id === element.id) && nextPairSwapData.push(element)
+        )
+        data.burnsAndMints.forEach(
+          element =>
+            !nextPairBurnsAndMintsData.some(el => el.id === element.id) && nextPairBurnsAndMintsData.push(element)
+        )
+
+        updatedAdapters[key][pairId] = {
+          ...updatedAdapters[key][pairId],
+          swaps: {
+            data: nextPairSwapData,
+            hasMore,
+          },
+          burnsAndMints: {
+            data: nextPairBurnsAndMintsData,
+            hasMore,
+          },
+        }
+      })
+
+      state.adapters = updatedAdapters
     },
 
     // TODO: UPDATE ACTION TO HANDLE BOTH SWAPS AND ACTIVITY DATA

--- a/src/services/AdvancedTradingView/store/advancedTradingView.reducer.ts
+++ b/src/services/AdvancedTradingView/store/advancedTradingView.reducer.ts
@@ -8,7 +8,7 @@ import {
   SetSwapsActionPayload,
   SetSwapsBurnsAndMintsActionPayload,
 } from '../adapters/baseAdapter/base.types'
-import { AdapterType, InitialState } from '../advancedTradingView.types'
+import { AdapterPayloadType, AdapterType, InitialState } from '../advancedTradingView.types'
 
 export const initialState: InitialState = {
   pair: {
@@ -76,8 +76,8 @@ const advancedTradingViewSlice = createSlice({
       action.payload.forEach(adapter => {
         const { key, pairId, data, hasMore } = adapter
 
-        const nextPairSwapData = state.adapters[key][pairId]?.['swaps']?.data ?? []
-        const nextPairBurnsAndMintsData = state.adapters[key][pairId]?.['burnsAndMints']?.data ?? []
+        const nextPairSwapData = state.adapters[key][pairId]?.[AdapterPayloadType.SWAPS]?.data ?? []
+        const nextPairBurnsAndMintsData = state.adapters[key][pairId]?.[AdapterPayloadType.BURNS_AND_MINTS]?.data ?? []
 
         data.swaps.forEach(
           element => !nextPairSwapData.some(el => el.id === element.id) && nextPairSwapData.push(element)
@@ -112,7 +112,7 @@ const advancedTradingViewSlice = createSlice({
       action.payload.forEach(adapter => {
         const { key, pairId, data, hasMore } = adapter
 
-        const nextPairData = state.adapters[key][pairId]?.['swaps']?.data ?? []
+        const nextPairData = state.adapters[key][pairId]?.[AdapterPayloadType.SWAPS]?.data ?? []
 
         data.forEach(element => !nextPairData.some(el => el.id === element.id) && nextPairData.push(element))
 
@@ -139,7 +139,7 @@ const advancedTradingViewSlice = createSlice({
       action.payload.forEach(adapter => {
         const { key, pairId, data, hasMore } = adapter
 
-        const nextPairData = state.adapters[key][pairId]?.['burnsAndMints']?.data ?? []
+        const nextPairData = state.adapters[key][pairId]?.[AdapterPayloadType.BURNS_AND_MINTS]?.data ?? []
 
         data.forEach(element => !nextPairData.some(el => el.id === element.id) && nextPairData.push(element))
 

--- a/src/services/AdvancedTradingView/store/advancedTradingView.reducer.ts
+++ b/src/services/AdvancedTradingView/store/advancedTradingView.reducer.ts
@@ -64,6 +64,31 @@ const advancedTradingViewSlice = createSlice({
       }
     },
 
+    // TODO: UPDATE ACTION TO HANDLE BOTH SWAPS AND ACTIVITY DATA
+    setSwapsDataForAllPairs: (state: InitialState, action: PayloadAction<Array<SetSwapsActionPayload>>) => {
+      const updatedAdapters: AdapterType = {
+        ...state.adapters,
+      }
+
+      action.payload.forEach(adapter => {
+        const { key, pairId, data, hasMore } = adapter
+
+        const nextPairData = state.adapters[key][pairId]?.['swaps']?.data ?? []
+
+        data.forEach(element => !nextPairData.some(el => el.id === element.id) && nextPairData.push(element))
+
+        updatedAdapters[key][pairId] = {
+          ...updatedAdapters[key][pairId],
+          swaps: {
+            data: nextPairData,
+            hasMore,
+          },
+        }
+      })
+
+      state.adapters = updatedAdapters
+    },
+
     setBurnsAndMintsDataForAllPairs: (
       state: InitialState,
       action: PayloadAction<Array<SetBurnsAndMintsActionPayload>>
@@ -82,31 +107,6 @@ const advancedTradingViewSlice = createSlice({
         updatedAdapters[key][pairId] = {
           ...updatedAdapters[key][pairId],
           burnsAndMints: {
-            data: nextPairData,
-            hasMore,
-          },
-        }
-      })
-
-      state.adapters = updatedAdapters
-    },
-
-    // TODO: UPDATE ACTION TO HANDLE BOTH SWAPS AND ACTIVITY DATA
-    setSwapsDataForAllPairs: (state: InitialState, action: PayloadAction<Array<SetSwapsActionPayload>>) => {
-      const updatedAdapters: AdapterType = {
-        ...state.adapters,
-      }
-
-      action.payload.forEach(adapter => {
-        const { key, pairId, data, hasMore } = adapter
-
-        const nextPairData = state.adapters[key][pairId]?.['swaps']?.data ?? []
-
-        data.forEach(element => !nextPairData.some(el => el.id === element.id) && nextPairData.push(element))
-
-        updatedAdapters[key][pairId] = {
-          ...updatedAdapters[key][pairId],
-          swaps: {
             data: nextPairData,
             hasMore,
           },

--- a/src/services/AdvancedTradingView/useAdvancedTradingView.hook.ts
+++ b/src/services/AdvancedTradingView/useAdvancedTradingView.hook.ts
@@ -133,22 +133,28 @@ export const useAdvancedTradingView = () => {
         setIsFetched(false)
 
         try {
-          await Promise.allSettled([
-            advancedTradingViewAdapter.fetchPairTradesBulkUpdate({
-              inputToken,
-              outputToken,
-              amountToFetch: pairTradesAmountToFetch,
-              isFirstFetch: true,
-              refreshing: true,
-            }),
-            advancedTradingViewAdapter.fetchPairActivityBulkUpdate({
-              inputToken,
-              outputToken,
-              amountToFetch: pairActivityAmountToFetch,
-              isFirstFetch: true,
-              refreshing: true,
-            }),
-          ])
+          await advancedTradingViewAdapter.fetchPairTradesAndActivityBulkUpdate({
+            inputToken,
+            outputToken,
+            amountToFetch: pairTradesAmountToFetch,
+          })
+
+          // await Promise.allSettled([
+          //   advancedTradingViewAdapter.fetchPairTradesBulkUpdate({
+          //     inputToken,
+          //     outputToken,
+          //     amountToFetch: pairTradesAmountToFetch,
+          //     isFirstFetch: true,
+          //     refreshing: true,
+          //   }),
+          //   advancedTradingViewAdapter.fetchPairActivityBulkUpdate({
+          //     inputToken,
+          //     outputToken,
+          //     amountToFetch: pairActivityAmountToFetch,
+          //     isFirstFetch: true,
+          //     refreshing: true,
+          //   }),
+          // ])
         } catch (e) {
           console.error(e)
         } finally {


### PR DESCRIPTION
# Background

Resolves #1586.

After thorough inspection of **Advanced Trading View** mode and updates data dispatching optimization, I've noticed much room for improvement of data fetching. Right now, we are sending at least 10 API calls every 15 seconds reaching out for `swaps`, `burns` and `mints`. Data of each of those calls was dispatched to **Redux** separately, now it is dispatched in two chunks, one for `swaps` and the other for `burns` and `mints`; that part was updated in my previous pull request.

Considering we're using **GraphQL** for data fetching there is more room for optimisation as query language allows requesting of custom data and in that way we can significantly reduce the number of calls and number of actions that are dispatched to **Redux**.

# Updates

I wrote new fetching queries together with new fetching functions, updated and created new types which were necessary, updated both base and **UniswapV3** adapters, updated adapters configuration, created new **Redux** actions and updated `useAdvancedTradingView` hook. These updates improve next:
- number of fetching calls is reduced by twice
- we are reaching for all of the data with the same call
- now we have clear separation between background, get fresh data calls and load older data calls
- we are altering the whole advanced trading view **Redux** state in the same action now.

# In the Future

We should consider removing excessive functionalities and creating better structure for **Advanced Trading View** part of the repository. Some parts of the application, mode, need type strengthening and everything should be componentized. We should consider separation of huge chunks of code into smaller pieces split by functionality and decoupling of logic from UI.

🍀